### PR TITLE
Display all missing but required values

### DIFF
--- a/src/libcmdline/CommandLine.cs
+++ b/src/libcmdline/CommandLine.cs
@@ -1145,15 +1145,18 @@ namespace CommandLine
 
         private bool EnforceRequiredRule()
         {
+            bool requiredRulesAllMet = true;
             foreach (OptionInfo option in _map.Values)
             {
                 if (option.Required && !option.IsDefined)
                 {
                     BuildAndSetPostParsingStateIfNeeded(this.RawOptions, option, true, null);
-                    return false;
+                    requiredRulesAllMet = false;
                 }
             }
-            return true;
+
+
+            return requiredRulesAllMet;
         }
 
         private bool EnforceMutuallyExclusiveMap()
@@ -1944,7 +1947,9 @@ namespace CommandLine
         public static TAttribute GetAttribute<TAttribute>()
             where TAttribute : Attribute
         {
-            object[] a = Assembly.GetEntryAssembly().GetCustomAttributes(typeof(TAttribute), false);
+            Assembly assemblyFromWhichToPullInformation = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+
+            object[] a = assemblyFromWhichToPullInformation.GetCustomAttributes(typeof(TAttribute), false);
             if (a == null || a.Length <= 0) return null;
             return (TAttribute)a[0];
         }

--- a/src/tests/Text/HelpTextFixture.cs
+++ b/src/tests/Text/HelpTextFixture.cs
@@ -414,7 +414,21 @@ namespace CommandLine.Text.Tests
                 new string[] { "-iIN.FILE", "-oOUT.FILE", "--offset", "zero", "-pa" }, options);
 
             Assert.IsFalse(result);
-        }		
+        }
+
+
+    [Test]
+        public void MultipleRequiredFields_WithMoreThanOneRequiredFieldNotSpecified_ReportsAllMissingRequiredFields()
+        {
+          var options = new ComplexOptions();
+          using (var writer = new StringWriter())
+          {
+            new CommandLineParser(new CommandLineParserSettings(false,  false, writer)).ParseArguments(new string[0], options, writer);
+
+            Assert.AreEqual(2, options.InternalLastPostParsingState.Errors.Count);
+          }
+        }
+    
         #endregion
 
         private void CustomizeOptionsFormat_FormatOptionHelpText(object sender, FormatOptionHelpTextEventArgs e)


### PR DESCRIPTION
If more than one parameter was specified as required but missing, only
the first in the "Option" class was displayed as in error. Now
displaying all of them.

Also changed reflection utility to get either the entry assembly
(current) or the executing assembly. This was throwing exceptions
running tests from the CodeRush test runner.
