### PR TITLE
Add support for Value property on MultiLineTextAttributes

### DIFF
--- a/src/libcmdline/CommandLineText.cs
+++ b/src/libcmdline/CommandLineText.cs
@@ -423,26 +423,50 @@ namespace CommandLine.Text
             _line5 = line5;
         }
 
+		// use protected virtual in case a derived class wants to override or call this
+		// Let's preserve blank lines if user intended by skipping a line
+		protected virtual int GetLastLineWithText( string[] strArray)
+		{
+			int index = Array.FindLastIndex( strArray, ( str ) => { return !string.IsNullOrEmpty( str ); } );
+
+			// remember FindLastIndex returns zero-based index
+			return index + 1;
+		}
+
+		public virtual string Value
+		{
+			get
+			{
+				var value = new StringBuilder( string.Empty );
+				var strArray = new string[] { _line1, _line2, _line3, _line4, _line5 };
+				for (int i = 0; i < GetLastLineWithText( strArray ); i++)
+				{
+					value.AppendLine( strArray[i] );
+				}
+				return value.ToString();
+			}
+		}
+
         internal void AddToHelpText(HelpText helpText, bool before)
         {
-            if (before)
-            {
-                if (!string.IsNullOrEmpty(_line1)) helpText.AddPreOptionsLine(_line1);
-                if (!string.IsNullOrEmpty(_line2)) helpText.AddPreOptionsLine(_line2);
-                if (!string.IsNullOrEmpty(_line3)) helpText.AddPreOptionsLine(_line3);
-                if (!string.IsNullOrEmpty(_line4)) helpText.AddPreOptionsLine(_line4);
-                if (!string.IsNullOrEmpty(_line5)) helpText.AddPreOptionsLine(_line5);
-            }
-            else
-            {
-                if (!string.IsNullOrEmpty(_line1)) helpText.AddPostOptionsLine(_line1);
-                if (!string.IsNullOrEmpty(_line2)) helpText.AddPostOptionsLine(_line2);
-                if (!string.IsNullOrEmpty(_line3)) helpText.AddPostOptionsLine(_line3);
-                if (!string.IsNullOrEmpty(_line4)) helpText.AddPostOptionsLine(_line4);
-                if (!string.IsNullOrEmpty(_line5)) helpText.AddPostOptionsLine(_line5);
-            }
+			// before flag only distinguishes which action is called, 
+			// so refactor common code and call with appropriate action
+			if (before)
+				AddToHelpText( helpText.AddPreOptionsLine );
+			else
+				AddToHelpText( helpText.AddPostOptionsLine );
         }
-    }
+
+		internal void AddToHelpText( Action<string> action )
+		{
+			var strArray = new string[] { _line1, _line2, _line3, _line4, _line5 };
+			Array.ForEach( strArray, ( line ) =>
+			{
+				if (!string.IsNullOrEmpty( line ))
+					action( line );
+			} );
+		}
+	}
 
     /// <summary>
     /// Models a multiline assembly license text.

--- a/src/tests/CommandLine.Tests.csproj
+++ b/src/tests/CommandLine.Tests.csproj
@@ -40,6 +40,7 @@
   </ItemGroup>
   <ItemGroup />
   <ItemGroup>
+    <Compile Include="Text\MultiLineTextAttributeFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="BaseFixture.cs" />
     <Compile Include="CommandLineParserBaseFixture.cs" />

--- a/src/tests/Text/MultiLineTextAttributeFixture.cs
+++ b/src/tests/Text/MultiLineTextAttributeFixture.cs
@@ -1,0 +1,65 @@
+﻿#region License
+//
+// Command Line Library: MultiLineTextAttributeFixture.cs
+//
+// Author:
+//   Robert Kayman (rkayman@gmail.com) / https://github.com/rkayman
+// 
+// Copyright (C) 2013 Robert Kayman
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+#endregion
+#region Using Directives
+using CommandLine;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using Should.Fluent;
+#endregion
+
+namespace CommandLine.Text.Tests
+{
+	[TestFixture]
+	public sealed class MultiLineTextAttributeFixture
+	{
+		[Test]
+		public void AssemblyLicenseShouldOfferReadOnlyPropertyNamedValue()
+		{
+			IEnumerable<AssemblyLicenseAttribute> licenseAttributes = this.GetType().Assembly.GetCustomAttributes( typeof( AssemblyLicenseAttribute ), false ) as AssemblyLicenseAttribute[];
+
+			licenseAttributes.Count().Should().Equal( 1 );
+
+			string license = licenseAttributes.Single().Value;
+			string[] lines = license.Split( new[] { Environment.NewLine }, StringSplitOptions.None );
+			lines[0].Should().Equal( @"This is free software. You may redistribute copies of it under the terms of" );
+			lines[1].Should().Equal( @"the MIT License <http://www.opensource.org/licenses/mit-license.php>." );
+		}
+
+		[Test]
+		public void AssemblyUsageShouldOfferReadOnlyPropertyNamedValue()
+		{
+			IEnumerable<AssemblyUsageAttribute> usageAttributes = this.GetType().Assembly.GetCustomAttributes( typeof( AssemblyUsageAttribute ), false ) as AssemblyUsageAttribute[];
+
+			usageAttributes.Count().Should().Equal( 1 );
+			usageAttributes.Single().Value.Should().Equal( @"[no usage, this is a dll]" + Environment.NewLine );
+		}
+	}
+}


### PR DESCRIPTION
Added Value property to MultiLineTextAttribute so that someone can create their own help text.

Also refactored AddToHelpText() to allow for externally calling formatting engine of CommandLineParser so that, in the future, can easily allow someone to leverage the formatting capabilities of CommandLineParser/MultiLineTextAttributes.  In other words, future support of a function called GetFormattedValue on MultiLineTextAttribute).

Also added tests for new Value property in a new fixture.  Hopefully put the new fixture in the right place ;-).
