### PR TITLE
Fixed issue where it was treating 'help' as the verb that usage info was...

### DIFF
--- a/src/libcmdline/Parser.cs
+++ b/src/libcmdline/Parser.cs
@@ -480,7 +480,7 @@ namespace CommandLine
                 if (string.Compare(args[0], helpInfo.Right.LongName, GetStringComparison(_settings)) == 0)
                 {
                     // User explicitly requested help
-                    var verb = args.FirstOrDefault();
+                    var verb = args.ElementAtOrDefault(1);
                     if (verb != null)
                     {
                         var verbOption = optionMap[verb];


### PR DESCRIPTION
... requested for.

Let's say that I have an application called 'example' that has a verb called 'dothing'. If I entered the following on the console:

```
example help dothing
```

The usage text displayed isn't for the verb specified but the default usage text.
