### PR TITLE
Support git-style "--" argument behaviour

### DIFF
--- a/src/libcmdline/ParserSettings.cs
+++ b/src/libcmdline/ParserSettings.cs
@@ -43,6 +43,8 @@ namespace CommandLine
         private bool _ignoreUnknownArguments;
         private TextWriter _helpWriter;
         private CultureInfo _parsingCulture;
+        private bool _enableDashDash;
+        private bool _doNotInterpretAfterFirstNonOption;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ParserSettings"/> class.
@@ -206,6 +208,39 @@ namespace CommandLine
             set
             {
                 PopsicleSetter.Set(Consumed, ref _ignoreUnknownArguments, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the "--" argument should be interpreted. If enabled,
+        /// the -- argument indicates that any following arguments should not be interpreted as options.
+        /// </summary>
+        public bool EnableDashDash
+        {
+            get
+            {
+                return _enableDashDash;
+            }
+
+            set
+            {
+                PopsicleSetter.Set(Consumed, ref _enableDashDash, value);
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether arguments following the first non-option argument should be interpreted as options.
+        /// </summary>
+        public bool DoNotInterpretAfterFirstNonOption
+        {
+            get
+            {
+                return _doNotInterpretAfterFirstNonOption;
+            }
+
+            set
+            {
+                PopsicleSetter.Set(Consumed, ref _doNotInterpretAfterFirstNonOption, value);
             }
         }
 


### PR DESCRIPTION
Hi Giacomo,

I needed to use commandline in a plugin-like scenario, but where I only wanted arguments to be interpreted at the start of the command line, up to the first non-option argument. In my case, we have a command line utility which roughly speaking represents a flexibly-structured pipeline of files and some command tokens (# in the example). There may be some global options, and each command token might have its own options too, which could quite possibly have the same names as the global options. For example:

myapp -v5 file1 # -v3 file2

So I need to:
- Process any global options which are at the start of the command line
- Pass all following arguments to a token parser
- The token parser will also check for options after the command token (-v3)

My options class:

```
class GlobalOptions 
{
    [Option( 'v' )]
    public int Verbosity { get; set; }

    [ValueList( typeof( List<string> ) )]
    public IList<string> RemainingArgs { get; set; }
}
```

By default, commandline will consider -v5 and -v3 as global options. By setting ParserSettings.DoNotInterpretAfterFirstNonOption to true, the parser stops trying to interpret options when it sees file1, and puts file1 and all subsequent arguments into RemainingArgs (including the -v3).

If the filename "file1" actually begins with a dash, it could be a problem, for example:

myapp -v5 -filename_starting_with_dash # -v3 file2

Many git commands have a workaround for this scenario: the double dash argument. The equivalent behaviour can be enabled by setting ParserSettings.EnableDashDash to true, and using:

myapp -v5 -- -filename_starting_with_dash # -v3 file2

I hope you'll see the usefulness of these changes and consider pulling them.

Many thanks,

Tom Glastonbury
