### PR TITLE
Add error information for unknown option

### DIFF
--- a/src/libcmdline/Parser.cs
+++ b/src/libcmdline/Parser.cs
@@ -168,8 +168,11 @@ namespace CommandLine
             object verbInstance = null;
 
             var result = DoParseArgumentsVerbs(args, options, ref verbInstance);
-            
-            onVerbCommand(args.FirstOrDefault() ?? string.Empty, result ? verbInstance : null);
+
+            if (result)
+            {
+              onVerbCommand(args.FirstOrDefault() ?? string.Empty, result ? verbInstance : null);
+            }
 
             return result;
         }

--- a/src/libcmdline/Parsing/OptionGroupParser.cs
+++ b/src/libcmdline/Parsing/OptionGroupParser.cs
@@ -26,11 +26,11 @@ namespace CommandLine.Parsing
 {
     internal sealed class OptionGroupParser : ArgumentParser
     {
-        private readonly bool _ignoreUnkwnownArguments;
+        private readonly bool _ignoreUnknownArguments;
 
-        public OptionGroupParser(bool ignoreUnkwnownArguments)
+        public OptionGroupParser(bool ignoreUnknownArguments)
         {
-            _ignoreUnkwnownArguments = ignoreUnkwnownArguments;
+            _ignoreUnknownArguments = ignoreUnknownArguments;
         }
 
         public override PresentParserState Parse(IArgumentEnumerator argumentEnumerator, OptionMap map, object options)
@@ -42,7 +42,15 @@ namespace CommandLine.Parsing
                 var option = map[optionGroup.Current];
                 if (option == null)
                 {
-                    return _ignoreUnkwnownArguments ? PresentParserState.MoveOnNextElement : PresentParserState.Failure;
+                  if (_ignoreUnknownArguments)
+                  {
+                    return PresentParserState.MoveOnNextElement;
+                  }
+                  else
+                  {
+                    this.PostParsingState.Add(new ParsingError(null, argumentEnumerator.Current, false) { IsUnknown = true });
+                    return PresentParserState.Failure;
+                  }
                 }
 
                 option.IsDefined = true;

--- a/src/libcmdline/ParsingError.cs
+++ b/src/libcmdline/ParsingError.cs
@@ -49,6 +49,14 @@ namespace CommandLine
         public BadOptionInfo BadOption { get; private set; }
 
         /// <summary>
+        /// Gets or sets a value indicating whether this <see cref="CommandLine.ParsingError"/> indicates unknown option.
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if violates required; otherwise, <c>false</c>.
+        /// </value>
+        public bool IsUnknown { get; set; }
+
+        /// <summary>
         /// Gets or sets a value indicating whether this <see cref="CommandLine.ParsingError"/> violates required.
         /// </summary>
         /// <value>

--- a/src/libcmdline/Text/BaseSentenceBuilder.cs
+++ b/src/libcmdline/Text/BaseSentenceBuilder.cs
@@ -73,5 +73,11 @@ namespace CommandLine.Text
         {
             return new EnglishSentenceBuilder();
         }
+
+        /// <summary>
+        /// Gets a string containing the sentence 'unknown'.
+        /// </summary>
+        /// <value>The sentence 'unknown'.</value>
+        public abstract string Unknown { get; }
     }
 }

--- a/src/libcmdline/Text/EnglishSentenceBuilder.cs
+++ b/src/libcmdline/Text/EnglishSentenceBuilder.cs
@@ -82,5 +82,14 @@ namespace CommandLine.Text
         {
             get { return "ERROR(S):"; }
         }
+
+        /// <summary>
+        /// Gets a string containing the sentence 'unknown' in english.
+        /// </summary>
+        /// <value>The sentence 'unknown' in english.</value>
+        public override string Unknown
+        {
+          get { return "unknown"; }
+        }
     }
 }

--- a/src/libcmdline/Text/HelpText.cs
+++ b/src/libcmdline/Text/HelpText.cs
@@ -459,42 +459,50 @@ namespace CommandLine.Text
             {
                 var line = new StringBuilder();
                 line.Append(indent.Spaces());
-                if (e.BadOption.ShortName != null)
-                {
-                    line.Append('-');
-                    line.Append(e.BadOption.ShortName);
-                    if (!string.IsNullOrEmpty(e.BadOption.LongName))
-                    {
-                        line.Append('/');
-                    }
-                }
 
-                if (!string.IsNullOrEmpty(e.BadOption.LongName))
+                if (e.IsUnknown)
                 {
-                    line.Append("--");
-                    line.Append(e.BadOption.LongName);
+                  line.Append(e.BadOption.LongName + " " + _sentenceBuilder.Unknown + " " + _sentenceBuilder.OptionWord);
                 }
-
-                line.Append(" ");
-                line.Append(e.ViolatesRequired ?
-                    _sentenceBuilder.RequiredOptionMissingText :
-                    _sentenceBuilder.OptionWord);
-                if (e.ViolatesFormat)
+                else
                 {
+                  if (e.BadOption.ShortName != null)
+                  {
+                      line.Append('-');
+                      line.Append(e.BadOption.ShortName);
+                      if (!string.IsNullOrEmpty(e.BadOption.LongName))
+                      {
+                          line.Append('/');
+                      }
+                  }
+
+                  if (!string.IsNullOrEmpty(e.BadOption.LongName))
+                  {
+                      line.Append("--");
+                      line.Append(e.BadOption.LongName);
+                  }
+
+                  line.Append(" ");
+                  line.Append(e.ViolatesRequired ?
+                      _sentenceBuilder.RequiredOptionMissingText :
+                      _sentenceBuilder.OptionWord);
+                  if (e.ViolatesFormat)
+                  {
                     line.Append(" ");
                     line.Append(_sentenceBuilder.ViolatesFormatText);
-                }
+                  }
 
-                if (e.ViolatesMutualExclusiveness)
-                {
+                  if (e.ViolatesMutualExclusiveness)
+                  {
                     if (e.ViolatesFormat || e.ViolatesRequired)
                     {
-                        line.Append(" ");
-                        line.Append(_sentenceBuilder.AndWord);
+                      line.Append(" ");
+                      line.Append(_sentenceBuilder.AndWord);
                     }
 
                     line.Append(" ");
                     line.Append(_sentenceBuilder.ViolatesMutualExclusivenessText);
+                  }
                 }
 
                 line.Append('.');


### PR DESCRIPTION
Dear Sir:

I am using your commandlineparser library now. It is really helpful. Thank you so much for sharing it.

I found that if an option was unknown, the parsing procedure would be failed but no error information was returned. It may confuse the end user. So I made some changes to display such error information. Hope it will be useful.

Best,

Quanhu "Tiger" Sheng
