### PR TITLE
-Adding AddEnumValuesToHelpText option to HelpText.cs

### DIFF
--- a/CommandLine.sln
+++ b/CommandLine.sln
@@ -13,9 +13,14 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Welcome", ".Welcome", "{D9
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "FSharp", "FSharp", "{751E6303-1623-4418-B298-4FF97DA5C86E}"
 EndProject
-Project("{4925A630-B079-445d-BCD4-3A9C94FE9307}") = "CommandLine.FSharp", "src\CommandLine.FSharp\CommandLine.FSharp.fsproj", "DFB97974-E2CC-42E6-BEB6-B6403FCB8B63"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "CommandLine.FSharp", "src\CommandLine.FSharp\CommandLine.FSharp.fsproj", "{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}"
 EndProject
-Project("{4925A630-B079-445d-BCD4-3A9C94FE9307}") = "CommandLine.FSharp.Tests", "src\CommandLine.FSharp.Tests\CommandLine.FSharp.Tests.fsproj", "54235AC4-60F1-4A3F-B218-3896B794043D"
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "CommandLine.FSharp.Tests", "src\CommandLine.FSharp.Tests\CommandLine.FSharp.Tests.fsproj", "{54235AC4-60F1-4A3F-B218-3896B794043D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{C37353EF-032B-484B-B0BD-ABDED8589732}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\packages.config = .nuget\packages.config
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -23,31 +28,27 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Release|Any CPU.Build.0 = Release|Any CPU
-		{54235AC4-60F1-4A3F-B218-3896B794043D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{54235AC4-60F1-4A3F-B218-3896B794043D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{54235AC4-60F1-4A3F-B218-3896B794043D}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{54235AC4-60F1-4A3F-B218-3896B794043D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Release|Any CPU.Build.0 = Release|Any CPU
 		{E1BD3C65-49C3-49E7-BABA-C60980CB3F20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{E1BD3C65-49C3-49E7-BABA-C60980CB3F20}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E1BD3C65-49C3-49E7-BABA-C60980CB3F20}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E1BD3C65-49C3-49E7-BABA-C60980CB3F20}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(NestedProjects) = preSolution
-		DFB97974-E2CC-42E6-BEB6-B6403FCB8B63 = {751E6303-1623-4418-B298-4FF97DA5C86E}
-		54235AC4-60F1-4A3F-B218-3896B794043D = {751E6303-1623-4418-B298-4FF97DA5C86E}
-	EndGlobalSection
-	GlobalSection(MonoDevelopProperties) = preSolution
-		StartupItem = src\CommandLine\CommandLine.csproj
+		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0A15C4D2-B3E9-43AB-8155-1B39F7AC8A5E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{DFB97974-E2CC-42E6-BEB6-B6403FCB8B63}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54235AC4-60F1-4A3F-B218-3896B794043D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54235AC4-60F1-4A3F-B218-3896B794043D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54235AC4-60F1-4A3F-B218-3896B794043D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54235AC4-60F1-4A3F-B218-3896B794043D}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(MonoDevelopProperties) = preSolution
+		StartupItem = src\CommandLine\CommandLine.csproj
 	EndGlobalSection
 EndGlobal

--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <ProductVersion>12.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -56,6 +58,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>Properties\SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="Fakes\FakeOptionsWithHelpTextEnum.cs" />
     <Compile Include="Fakes\FakeOptionsWithDouble.cs" />
     <Compile Include="Fakes\FakeOptionsWithEnum.cs" />
     <Compile Include="Fakes\FakeOptionsWithMetaValue.cs" />
@@ -88,6 +91,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/CommandLine.Tests/Fakes/FakeOptionsWithHelpTextEnum.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionsWithHelpTextEnum.cs
@@ -1,0 +1,22 @@
+﻿// Copyright 2005-2013 Giacomo Stelluti Scala & Contributors. All rights reserved. See doc/License.md in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace CommandLine.Tests.Fakes
+{
+    enum Shapes
+    {
+        Circle,
+        Square,
+        Triangle
+    }
+
+    class FakeOptionsWithHelpTextEnum
+    {
+        [Option(HelpText = "Define a string value here.")]
+        public string StringValue { get; set; }
+
+        [Option(HelpText="Define a enum value here.")]
+        public Shapes Shape { get; set; }
+    }
+}

--- a/src/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/OptionMapperTests.cs
@@ -24,7 +24,7 @@ namespace CommandLine.Tests.Unit.Core
             var specProps = new[]
                 {
                     SpecificationProperty.Create(
-                        new OptionSpecification("x", string.Empty, false, string.Empty, -1, -1, Maybe.Nothing<object>(), typeof(bool), string.Empty, string.Empty), 
+                        new OptionSpecification("x", string.Empty, false, string.Empty, -1, -1, Maybe.Nothing<object>(), typeof(bool), string.Empty, string.Empty, new List<string>()), 
                         typeof(FakeOptions).GetProperties().Single(p => p.Name.Equals("BoolValue", StringComparison.Ordinal)),
                         Maybe.Nothing<object>())
                 };

--- a/src/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
@@ -21,8 +21,8 @@ namespace CommandLine.Tests.Unit.Core
                 };
             var specs =new[]
                 {
-                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, typeof(string), string.Empty, string.Empty),
-                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, typeof(IEnumerable<int>), string.Empty, string.Empty)
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, typeof(string), string.Empty, string.Empty, new List<string>()),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, typeof(IEnumerable<int>), string.Empty, string.Empty, new List<string>())
                 };
 
             // Exercize system 

--- a/src/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/src/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -61,7 +61,50 @@ namespace CommandLine.Tests.Unit.Text
             Assert.Equal("-i               Define a int sequence here.", lines[2]);
             Assert.Equal("-x               Define a boolean or switch value here.", lines[3]);
             Assert.Equal("--help           Display this help screen.", lines[4]);
-            Assert.Equal( "post-options", lines[5]);
+            Assert.Equal("post-options", lines[5]);
+            // Teardown
+        }
+
+        [Fact]
+        public void Create_instance_with_enum_options_enabled()
+        {
+            // Fixture setup
+            // Exercize system 
+            var sut = new HelpText { AddDashesToOption = true, AddEnumValuesToHelpText = true }
+                .AddPreOptionsLine("pre-options")
+                .AddOptions(new FakeOptionsWithHelpTextEnum())
+                .AddPostOptionsLine("post-options");
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines().TrimStringArray();
+            Assert.Equal("pre-options", lines[0]);
+            Assert.Equal("--stringvalue    Define a string value here.", lines[1]);
+            Assert.Equal("--shape          Define a enum value here. Valid values: Circle, Square,", lines[2]);
+            Assert.Equal("Triangle", lines[3]);
+            Assert.Equal("--help           Display this help screen.", lines[4]);
+            Assert.Equal("post-options", lines[5]);
+            // Teardown
+        }
+
+        [Fact]
+        public void Create_instance_with_enum_options_disabled()
+        {
+            // Fixture setup
+            // Exercize system 
+            var sut = new HelpText { AddDashesToOption = true }
+                .AddPreOptionsLine("pre-options")
+                .AddOptions(new FakeOptionsWithHelpTextEnum())
+                .AddPostOptionsLine("post-options");
+
+            // Verify outcome
+
+            var lines = sut.ToString().ToNotEmptyLines().TrimStringArray();
+            Assert.Equal("pre-options", lines[0]);
+            Assert.Equal("--stringvalue    Define a string value here.", lines[1]);
+            Assert.Equal("--shape          Define a enum value here.", lines[2]);
+            Assert.Equal("--help           Display this help screen.", lines[3]);
+            Assert.Equal("post-options", lines[4]);
             // Teardown
         }
 

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -12,8 +12,9 @@ namespace CommandLine.Core
         private readonly string setName;
         private readonly string helpText;
         private readonly string metaValue;
+        private readonly System.Collections.Generic.IEnumerable<string> enumValues;
 
-        public OptionSpecification(string shortName, string longName, bool required, string setName, int min, int max, Maybe<object> defaultValue, System.Type conversionType, string helpText, string metaValue)
+        public OptionSpecification(string shortName, string longName, bool required, string setName, int min, int max, Maybe<object> defaultValue, System.Type conversionType, string helpText, string metaValue, System.Collections.Generic.IEnumerable<string> enumValues)
             : base(SpecificationType.Option, required, min, max, defaultValue, conversionType)
         {
             this.shortName = shortName;
@@ -21,9 +22,10 @@ namespace CommandLine.Core
             this.setName = setName;
             this.helpText = helpText;
             this.metaValue = metaValue;
+            this.enumValues = enumValues;
         }
 
-        public static OptionSpecification FromAttribute(OptionAttribute attribute, System.Type conversionType)
+        public static OptionSpecification FromAttribute(OptionAttribute attribute, System.Type conversionType, System.Collections.Generic.IEnumerable<string> enumValues)
         {
             return new OptionSpecification(
                 attribute.ShortName,
@@ -35,7 +37,8 @@ namespace CommandLine.Core
                 attribute.DefaultValue.ToMaybe(),
                 conversionType,
                 attribute.HelpText,
-                attribute.MetaValue);
+                attribute.MetaValue,
+                enumValues);
         }
 
         public string ShortName
@@ -61,6 +64,11 @@ namespace CommandLine.Core
         public string MetaValue
         {
             get { return this.metaValue; }
+        }
+
+        public System.Collections.Generic.IEnumerable<string> EnumValues
+        {
+            get { return this.enumValues; }
         }
     }
 }

--- a/src/CommandLine/Core/Specification.cs
+++ b/src/CommandLine/Core/Specification.cs
@@ -67,14 +67,23 @@ namespace CommandLine.Core
 
         public static Specification FromProperty(PropertyInfo property)
         {
+            System.Collections.Generic.List<string> enumList = new System.Collections.Generic.List<string>();
+            if (property.PropertyType.IsEnum)
+            {
+                FieldInfo[] fieldArray = property.PropertyType.GetFields();
+                foreach (FieldInfo fInfo in fieldArray)
+                    if (!fInfo.IsSpecialName)
+                        enumList.Add(fInfo.Name);
+            }
+            
             var attrs = property.GetCustomAttributes(true);
             var oa = attrs.OfType<OptionAttribute>();
             if (oa.Count() == 1)
             {
-                var spec = OptionSpecification.FromAttribute(oa.Single(), property.PropertyType);
+                var spec = OptionSpecification.FromAttribute(oa.Single(), property.PropertyType, enumList);
                 if (spec.ShortName.Length == 0 && spec.LongName.Length == 0)
                 {
-                    return spec.WithLongName(property.Name.ToLowerInvariant());
+                    return spec.WithLongName(property.Name.ToLowerInvariant(), enumList);
                 }
                 return spec;
             }

--- a/src/CommandLine/Core/Specification.cs
+++ b/src/CommandLine/Core/Specification.cs
@@ -70,10 +70,7 @@ namespace CommandLine.Core
             System.Collections.Generic.List<string> enumList = new System.Collections.Generic.List<string>();
             if (property.PropertyType.IsEnum)
             {
-                FieldInfo[] fieldArray = property.PropertyType.GetFields();
-                foreach (FieldInfo fInfo in fieldArray)
-                    if (!fInfo.IsSpecialName)
-                        enumList.Add(fInfo.Name);
+                enumList.AddRange(Enum.GetNames(property.PropertyType));
             }
             
             var attrs = property.GetCustomAttributes(true);

--- a/src/CommandLine/Core/SpecificationExtensions.cs
+++ b/src/CommandLine/Core/SpecificationExtensions.cs
@@ -23,7 +23,7 @@ namespace CommandLine.Core
             return specification.Tag == SpecificationType.Value;
         }
 
-        public static OptionSpecification WithLongName(this OptionSpecification specification, string newLongName)
+        public static OptionSpecification WithLongName(this OptionSpecification specification, string newLongName, System.Collections.Generic.IEnumerable<string> enumValues)
         {
             return new OptionSpecification(
                 specification.ShortName,
@@ -35,7 +35,8 @@ namespace CommandLine.Core
                 specification.DefaultValue,
                 specification.ConversionType,
                 specification.HelpText,
-                specification.MetaValue);
+                specification.MetaValue,
+                enumValues);
         }
 
         public static IEnumerable<Specification> ThrowingValidate(this IEnumerable<Specification> specifications, IEnumerable<Tuple<Func<Specification, bool>, string>> guardsLookup)

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -26,6 +26,7 @@ namespace CommandLine.Text
         private bool additionalNewLineAfterOption;
         private StringBuilder optionsHelp;
         private bool addDashesToOption;
+        private bool addEnumValuesToHelpText;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="CommandLine.Text.HelpText"/> class.
@@ -168,6 +169,15 @@ namespace CommandLine.Text
         {
             get { return this.additionalNewLineAfterOption; }
             set { this.additionalNewLineAfterOption = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to add the values of an enum after the description of the option.
+        /// </summary>
+        public bool AddEnumValuesToHelpText
+        {
+            get { return this.addEnumValuesToHelpText; }
+            set { this.addEnumValuesToHelpText = value; }
         }
 
         /// <summary>
@@ -532,7 +542,8 @@ namespace CommandLine.Text
                        Maybe.Nothing<object>(),
                        typeof(bool),
                        verbTuple.Item1.HelpText,
-                       string.Empty))
+                       string.Empty,
+                       new List<string>()))
                     .Concat(new[] { this.CreateHelpEntry() });
         }
 
@@ -555,7 +566,7 @@ namespace CommandLine.Text
         private OptionSpecification CreateHelpEntry()
         {
             return new OptionSpecification(string.Empty, "help", false, string.Empty, -1, -1, Maybe.Nothing<object>(), typeof(bool),
-                this.sentenceBuilder.HelpCommandText(this.AddDashesToOption), string.Empty);
+                this.sentenceBuilder.HelpCommandText(this.AddDashesToOption), string.Empty, new List<string>());
         }
 
         private HelpText AddPreOptionsLine(string value, int maximumLength)
@@ -610,6 +621,11 @@ namespace CommandLine.Text
 
             this.optionsHelp.Append("    ");
             var optionHelpText = option.HelpText;
+
+            if (this.addEnumValuesToHelpText)
+                if (option.EnumValues.Count() > 0)
+                    optionHelpText += " Valid values: " + string.Join(", ", option.EnumValues);
+
             if (option.DefaultValue.IsJust())
             {
                 optionHelpText = "(Default: {0}) ".FormatLocal(option.DefaultValue.FromJust()) + optionHelpText;


### PR DESCRIPTION
When property AddEnumValuesToHelpText of HelpText is true, the help text generated includes a list of the valid  values of a property when its type is an enum.

The unit tests HelpText.Create_instance_with_enum_options_enabled() and HelpText.Create_instance_with_enum_options_disabled show how to use the AddEnumValuesToHelpText option.

The default value of AddEnumValuesToHelpText is false to avoid problems in existing code that uses HelpText class.