### PR TITLE
Fixed case where there are duplicate value arguments

### DIFF
--- a/src/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/TokenPartitionerTests.cs
@@ -10,7 +10,6 @@ namespace CommandLine.Tests.Unit.Core
 {
     public class TokenPartitionerTests
     {
-        
         [Fact]
         public void Partition_sequence_returns_sequence()
         {
@@ -28,6 +27,32 @@ namespace CommandLine.Tests.Unit.Core
             // Exercize system 
             var result = TokenPartitioner.Partition(
                 new[] { Token.Name("i"), Token.Value("10"), Token.Value("20"), Token.Value("30"), Token.Value("40") },
+                name => TypeLookup.GetDescriptorInfo(name, specs, StringComparer.InvariantCulture)
+                );
+
+            // Verify outcome
+            Assert.True(expectedSequence.All(a => result.Item1.Any(r => a.Key.Equals(r.Key) && a.Value.SequenceEqual(r.Value))));
+
+            // Teardown
+        }
+
+        [Fact]
+        public void Partition_sequence_returns_sequence_with_duplicates()
+        {
+            // Fixture setup
+            var expectedSequence = new[]
+                {
+                    new KeyValuePair<string, IEnumerable<string>>("i", new[] {"10", "10", "30", "40"}) 
+                };
+            var specs =new[]
+                {
+                    new OptionSpecification(string.Empty, "stringvalue", false, string.Empty, -1, -1, null, typeof(string), string.Empty, string.Empty),
+                    new OptionSpecification("i", string.Empty, false, string.Empty, 3, 4, null, typeof(IEnumerable<int>), string.Empty, string.Empty)
+                };
+
+            // Exercize system 
+            var result = TokenPartitioner.Partition(
+                new[] { Token.Name("i"), Token.Value("10"), Token.Value("10"), Token.Value("30"), Token.Value("40") },
                 name => TypeLookup.GetDescriptorInfo(name, specs, StringComparer.InvariantCulture)
                 );
 

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -18,14 +18,15 @@ namespace CommandLine.Core
                 IEnumerable<Token> tokens,
                 Func<string, Maybe<Tuple<DescriptorType, Maybe<int>>>> typeLookup)
         {
-            var switches = PartitionSwitches(tokens, typeLookup);
-            var tokensExceptSwitches = tokens.Except(switches);
-            var scalars = PartitionScalars(tokensExceptSwitches, typeLookup);
-            var tokensExceptSwitchesAndScalars = tokensExceptSwitches.Except(scalars);
-            var sequences = PartitionSequences(tokensExceptSwitchesAndScalars, typeLookup);
-            var tokensExceptSwitchesAndScalarsAndSeq = tokensExceptSwitchesAndScalars.Except(sequences);
-            var values = tokensExceptSwitchesAndScalarsAndSeq.Where(v => v.IsValue());
-            var errors = tokensExceptSwitchesAndScalarsAndSeq.Except(values);
+            var tokenList = tokens.ToList();
+            var switches = PartitionSwitches(tokenList, typeLookup).ToList();
+            var tokensExceptSwitches = tokenList.Where(x => !switches.Contains(x)).ToList();
+            var scalars = PartitionScalars(tokensExceptSwitches, typeLookup).ToList();
+            var tokensExceptSwitchesAndScalars = (tokensExceptSwitches.Where(x => !scalars.Contains(x))).ToList();
+            var sequences = PartitionSequences(tokensExceptSwitchesAndScalars, typeLookup).ToList();
+            var tokensExceptSwitchesAndScalarsAndSeq = tokensExceptSwitchesAndScalars.Where(x => !sequences.Contains(x)).ToList();
+            var values = tokensExceptSwitchesAndScalarsAndSeq.Where(v => v.IsValue()).ToList();
+            var errors = tokensExceptSwitchesAndScalarsAndSeq.Where(x => !values.Contains(x));
 
             return Tuple.Create(
                     switches.Select(t => CreateValue(t.Text,"true"))

--- a/src/CommandLine/Core/Tokenizer.cs
+++ b/src/CommandLine/Core/Tokenizer.cs
@@ -18,17 +18,17 @@ namespace CommandLine.Core
             var errors = new List<Error>();
             Action<Error> onError = e => errors.Add(e);
 
-            var tokens = from arg in arguments
-                         from token in !arg.StartsWith("-", StringComparison.Ordinal)
+            var tokens = (from arg in arguments
+                          from token in !arg.StartsWith("-", StringComparison.Ordinal)
                                ? new Token[] { Token.Value(arg) }
                                : arg.StartsWith("--", StringComparison.Ordinal)
                                      ? TokenizeLongName(arg, onError)
                                      : TokenizeShortName(arg, nameLookup)
-                         select token;
+                          select token).ToList();
 
-            var unkTokens = from t in tokens where t.IsName() && !nameLookup(t.Text) select t;
+            var unkTokens = (from t in tokens where t.IsName() && !nameLookup(t.Text) select t).ToList();
 
-            return StatePair.Create(tokens.Except(unkTokens), errors.Concat(from t in unkTokens select new UnknownOptionError(t.Text)));
+            return StatePair.Create(tokens.Where(x=>!unkTokens.Contains(x)), errors.Concat(from t in unkTokens select new UnknownOptionError(t.Text)));
         }
 
         public static StatePair<IEnumerable<Token>> PreprocessDashDash(


### PR DESCRIPTION
For instance, using all value type options parameters, the libary would not parse "Pull 10/1/13 10/1/13", the tokenizer would condense this into two tokens, "Pull 10/1/13".

The root causes is that .Except returns the set difference, rather than the bag difference, which removes duplicates. I reimplemented using lists and filter clauses, rather than excepts.