### PR TITLE
One option with Required doesn't need to be filled if another item of it...

### DIFF
--- a/src/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/src/CommandLine.Tests/CommandLine.Tests.csproj
@@ -13,6 +13,8 @@
     <FileAlignment>512</FileAlignment>
     <ProductVersion>12.0.0</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
+    <RestorePackages>true</RestorePackages>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -64,6 +66,7 @@
     <Compile Include="Fakes\FakeOptionsWithValues.cs" />
     <Compile Include="Fakes\FakeOptions.cs" />
     <Compile Include="Fakes\FakeOptionWithRequired.cs" />
+    <Compile Include="Fakes\FakeOptionWithRequiredAndSet.cs" />
     <Compile Include="Fakes\HelpFakes.cs" />
     <Compile Include="Fakes\VerbFakes.cs" />
     <Compile Include="StringExtensions.cs" />
@@ -86,8 +89,11 @@
       <Name>CommandLine</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/src/CommandLine.Tests/Fakes/FakeOptionWithRequiredAndSet.cs
+++ b/src/CommandLine.Tests/Fakes/FakeOptionWithRequiredAndSet.cs
@@ -1,0 +1,10 @@
+﻿namespace CommandLine.Tests.Fakes
+{
+    public class FakeOptionWithRequiredAndSet {
+        [Option("ftpurl", SetName = "SetA", Required = true)]
+        public string FtpUrl { get; set; }
+
+        [Option("weburl", SetName = "SetA",  Required = true)]
+        public string WebUrl { get; set; }
+    }
+}

--- a/src/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/InstanceBuilderTests.cs
@@ -235,6 +235,65 @@ namespace CommandLine.Tests.Unit.Core
         }
 
         [Fact]
+        public void Two_required_options_at_the_same_set_and_one_is_true() {
+            // Fixture setup
+            var expectedResult = new FakeOptionWithRequiredAndSet {
+                FtpUrl = "str1",
+                WebUrl = null
+            };
+            // Exercize system 
+            var result = InstanceBuilder.Build(
+                () => new FakeOptionWithRequiredAndSet(),
+                new[] { "--ftpurl", "str1"},
+                StringComparer.Ordinal,
+                CultureInfo.InvariantCulture);
+
+            // Verify outcome
+            expectedResult.ShouldHave().AllProperties().EqualTo(result.Value);
+            // Teardown
+        }
+
+
+        [Fact]
+        public void Two_required_options_at_the_same_set_and_both_are_true() {
+            // Fixture setup
+            var expectedResult = new FakeOptionWithRequiredAndSet {
+                FtpUrl = "str1",
+                WebUrl = "str2"
+            };
+            // Exercize system 
+            var result = InstanceBuilder.Build(
+                () => new FakeOptionWithRequiredAndSet(),
+                new[] { "--ftpurl", "str1", "--weburl", "str2" },
+                StringComparer.Ordinal,
+                CultureInfo.InvariantCulture);
+
+            // Verify outcome
+            expectedResult.ShouldHave().AllProperties().EqualTo(result.Value);
+            // Teardown
+        }
+
+        [Fact]
+        public void Two_required_options_at_the_same_set_and_none_are_true() {
+            // Fixture setup
+            var expectedResult = new[]
+            {
+                new MissingRequiredOptionError(new NameInfo("", "ftpurl")),
+                new MissingRequiredOptionError(new NameInfo("", "weburl"))
+            };
+            // Exercize system 
+            var result = InstanceBuilder.Build(
+                () => new FakeOptionWithRequiredAndSet(),
+                new[] {""},
+                StringComparer.Ordinal,
+                CultureInfo.InvariantCulture);
+
+            // Verify outcome
+            Assert.True(expectedResult.SequenceEqual(result.Errors));
+            // Teardown
+        }
+
+        [Fact]
         public void Omitting_required_option_gererates_MissingRequiredOptionError()
         {
             // Fixture setup


### PR DESCRIPTION
Hi,
I was trying to configure two items in a mutual exclusive set and I would like to have one of them required. Marking both of them required would result in a deadlock where I couldn't provide both of them and at the same time were required to do so.

With this fix:
One option with Required doesn't need to be filled if another item of its MutualSet is provided. 
In another words: only one item of a MutualSet with all items Required need to be provided.

Please, check the unit tests for more detail.