### PR TITLE
Makes boolean options falsible

### DIFF
--- a/src/libcmdline/Parsing/OptionGroupParser.cs
+++ b/src/libcmdline/Parsing/OptionGroupParser.cs
@@ -49,7 +49,9 @@ namespace CommandLine.Parsing
 
                 ArgumentParser.EnsureOptionArrayAttributeIsNotBoundToScalar(option);
 
-                if (argumentEnumerator.IsLast && optionGroup.IsLast)
+                //previous place
+
+                if (!option.IsBoolean && argumentEnumerator.IsLast && optionGroup.IsLast)
                 {
                     return PresentParserState.Failure;
                 }
@@ -60,26 +62,30 @@ namespace CommandLine.Parsing
                     if (!option.IsArray)
                     {
                         valueSetting = option.SetValue(optionGroup.GetRemainingFromNext(), options);
+                        if (!valueSetting && !option.IsBoolean)
+                        {
+                            DefineOptionThatViolatesFormat(option);
+                        }
+
+                        if (valueSetting || !option.IsBoolean)
+                            return ArgumentParser.BooleanToParserState(valueSetting);
+                    }
+
+                    if (!option.IsBoolean)
+                    {
+                        ArgumentParser.EnsureOptionAttributeIsArrayCompatible(option);
+
+                        var items = ArgumentParser.GetNextInputValues(argumentEnumerator);
+                        items.Insert(0, optionGroup.GetRemainingFromNext());
+
+                        valueSetting = option.SetValue(items, options);
                         if (!valueSetting)
                         {
                             DefineOptionThatViolatesFormat(option);
                         }
 
-                        return ArgumentParser.BooleanToParserState(valueSetting);
+                        return ArgumentParser.BooleanToParserState(valueSetting, true);
                     }
-
-                    ArgumentParser.EnsureOptionAttributeIsArrayCompatible(option);
-
-                    var items = ArgumentParser.GetNextInputValues(argumentEnumerator);
-                    items.Insert(0, optionGroup.GetRemainingFromNext());
-
-                    valueSetting = option.SetValue(items, options);
-                    if (!valueSetting)
-                    {
-                        DefineOptionThatViolatesFormat(option);
-                    }
-
-                    return ArgumentParser.BooleanToParserState(valueSetting, true);
                 }
 
                 if (!option.IsBoolean && !argumentEnumerator.IsLast && !ArgumentParser.IsInputValue(argumentEnumerator.Next))
@@ -115,6 +121,8 @@ namespace CommandLine.Parsing
 
                     return ArgumentParser.BooleanToParserState(valueSetting);
                 }
+
+                //old place close
 
                 if (!optionGroup.IsLast && map[optionGroup.Next] == null)
                 {

--- a/src/libcmdline/Parsing/OptionGroupParser.cs
+++ b/src/libcmdline/Parsing/OptionGroupParser.cs
@@ -49,49 +49,49 @@ namespace CommandLine.Parsing
 
                 ArgumentParser.EnsureOptionArrayAttributeIsNotBoundToScalar(option);
 
-                if (!option.IsBoolean)
+                if (argumentEnumerator.IsLast && optionGroup.IsLast)
                 {
-                    if (argumentEnumerator.IsLast && optionGroup.IsLast)
-                    {
-                        return PresentParserState.Failure;
-                    }
+                    return PresentParserState.Failure;
+                }
 
-                    bool valueSetting;
-                    if (!optionGroup.IsLast)
-                    {
-                        if (!option.IsArray)
-                        {
-                            valueSetting = option.SetValue(optionGroup.GetRemainingFromNext(), options);
-                            if (!valueSetting)
-                            {
-                                DefineOptionThatViolatesFormat(option);
-                            }
-
-                            return ArgumentParser.BooleanToParserState(valueSetting);
-                        }
-
-                        ArgumentParser.EnsureOptionAttributeIsArrayCompatible(option);
-
-                        var items = ArgumentParser.GetNextInputValues(argumentEnumerator);
-                        items.Insert(0, optionGroup.GetRemainingFromNext());
-
-                        valueSetting = option.SetValue(items, options);
-                        if (!valueSetting)
-                        {
-                            DefineOptionThatViolatesFormat(option);
-                        }
-
-                        return ArgumentParser.BooleanToParserState(valueSetting, true);
-                    }
-
-                    if (!argumentEnumerator.IsLast && !ArgumentParser.IsInputValue(argumentEnumerator.Next))
-                    {
-                        return PresentParserState.Failure;
-                    }
-
+                bool valueSetting;
+                if (!optionGroup.IsLast)
+                {
                     if (!option.IsArray)
                     {
-                        valueSetting = option.SetValue(argumentEnumerator.Next, options);
+                        valueSetting = option.SetValue(optionGroup.GetRemainingFromNext(), options);
+                        if (!valueSetting)
+                        {
+                            DefineOptionThatViolatesFormat(option);
+                        }
+
+                        return ArgumentParser.BooleanToParserState(valueSetting);
+                    }
+
+                    ArgumentParser.EnsureOptionAttributeIsArrayCompatible(option);
+
+                    var items = ArgumentParser.GetNextInputValues(argumentEnumerator);
+                    items.Insert(0, optionGroup.GetRemainingFromNext());
+
+                    valueSetting = option.SetValue(items, options);
+                    if (!valueSetting)
+                    {
+                        DefineOptionThatViolatesFormat(option);
+                    }
+
+                    return ArgumentParser.BooleanToParserState(valueSetting, true);
+                }
+
+                if (!option.IsBoolean && !argumentEnumerator.IsLast && !ArgumentParser.IsInputValue(argumentEnumerator.Next))
+                {
+                    return PresentParserState.Failure;
+                }
+
+                if (!option.IsArray)
+                {
+                    valueSetting = option.SetValue(argumentEnumerator.Next, options);
+                    if (!option.IsBoolean || valueSetting)
+                    {
                         if (!valueSetting)
                         {
                             DefineOptionThatViolatesFormat(option);
@@ -99,7 +99,10 @@ namespace CommandLine.Parsing
 
                         return ArgumentParser.BooleanToParserState(valueSetting, true);
                     }
+                }
 
+                if (!option.IsBoolean)
+                {
                     ArgumentParser.EnsureOptionAttributeIsArrayCompatible(option);
 
                     var moreItems = ArgumentParser.GetNextInputValues(argumentEnumerator);

--- a/src/tests/Unit/Parser/ParserFixture.cs
+++ b/src/tests/Unit/Parser/ParserFixture.cs
@@ -532,6 +532,22 @@ namespace CommandLine.Tests.Unit.Parser
             options.LastParserState.Errors.Count.Should().BeGreaterThan(0);
         }
         #endregion
+
+        [Fact]
+        public void Parse_falsible_boolean()
+        {
+            var options = new BooleanSetOptions();
+            var parser = new CommandLine.Parser();
+            var result = parser.ParseArguments(new string[] { "-a true", "-c false", "-d65" }, options);
+
+            result.Should().BeTrue();
+            options.BooleanOne.Should().BeTrue();
+            options.BooleanTwo.Should().BeFalse();
+            options.BooleanThree.Should().BeFalse();
+            options.NonBooleanValue.Should().Be(65D);
+            Console.WriteLine(options);
+        }
+
     }
 }
 


### PR DESCRIPTION
As discussed in issue #115 this makes a boolean option falsible. You can still optionally omit the 'true' or 'false' part.
