### PR TITLE
Allows negative decimal numbers as values

### DIFF
--- a/src/libcmdline/Extensions/StringExtensions.cs
+++ b/src/libcmdline/Extensions/StringExtensions.cs
@@ -40,7 +40,7 @@ namespace CommandLine.Extensions
         public static bool IsNumeric(this string value)
         {
             decimal temporary;
-            return decimal.TryParse(value, out temporary);
+            return decimal.TryParse(value, NumberStyles.Float | NumberStyles.Integer | NumberStyles.Number, CultureInfo.InvariantCulture, out temporary);
         }
 
         public static string FormatInvariant(this string value, params object[] arguments)


### PR DESCRIPTION
If you provided "-2.5" as a parameter value, the library was basically considering it wasn't a value, but another parameter.
