### PR TITLE
Fix test build on case sensitive file systems.

### DIFF
--- a/.nuget/NuGet.targets
+++ b/.nuget/NuGet.targets
@@ -41,7 +41,7 @@
     
     <PropertyGroup>
         <!-- NuGet command -->
-        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\nuget.exe</NuGetExePath>
+        <NuGetExePath Condition=" '$(NuGetExePath)' == '' ">$(NuGetToolsPath)\NuGet.exe</NuGetExePath>
         <PackageSources Condition=" $(PackageSources) == '' ">@(PackageSource)</PackageSources>
         
         <NuGetCommand Condition=" '$(OS)' == 'Windows_NT'">"$(NuGetExePath)"</NuGetCommand>


### PR DESCRIPTION
While trying to build the library on Ubuntu 14.04 I encountered an error when building the test build.

The actual file name of the file is NuGet.exe and the target file uses nuget.exe, which works on windows since its file system is not case sensitive by default, but does not on file systems which are not case sensitive.