### PR TITLE
Sequence with separator didn't work in verb scenario

### DIFF
--- a/src/CommandLine.Tests/Fakes/VerbFakes.cs
+++ b/src/CommandLine.Tests/Fakes/VerbFakes.cs
@@ -45,4 +45,14 @@ namespace CommandLine.Tests.Fakes
         public IEnumerable<string> Urls { get; set; }
     }
 
+    [Verb("sequence", HelpText = "Sequence options test.")]
+    class SequenceOptions
+    {
+        [Option("long-seq", Separator = ';')]
+        public IEnumerable<long> LongSequence { get; set; }
+
+        [Option('s', Min = 1, Max = 100, Separator = ',')]
+        public IEnumerable<string> StringSequence { get; set; }
+    }
+
 }

--- a/src/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -106,5 +106,47 @@ namespace CommandLine.Tests.Unit.Core
             expected.ShouldBeEquivalentTo(result.Value);
             // Teardown
         }    
+
+        [Fact]
+        public void Parse_sequence_verb_returns_verb_instance()
+        {
+            // Fixture setup
+            var expected = new SequenceOptions { LongSequence = new long[] { }, StringSequence = new[] { "aa", "b" } };
+
+            // Exercize system 
+            var result = InstanceChooser.Choose(
+                new[] { typeof(AddOptions), typeof(CommitOptions), typeof(CloneOptions), typeof(SequenceOptions) },
+                new[] { "sequence", "-s", "aa", "b" },
+                StringComparer.Ordinal,
+                CultureInfo.InvariantCulture);
+
+            // Verify outcome
+            Assert.IsType<SequenceOptions>(result.Value);
+            expected.ShouldBeEquivalentTo(result.Value);
+            // Teardown
+        }
+
+        [Theory]
+        [InlineData(new[] { "sequence", "-s", "here-one-elem-but-no-sep" }, new[] { "here-one-elem-but-no-sep" })]
+        [InlineData(new[] { "sequence", "-shere-one-elem-but-no-sep" }, new[] { "here-one-elem-but-no-sep" })]
+        [InlineData(new[] { "sequence", "-s", "eml1@xyz.com,test@unit.org,xyz@srv.it" }, new[] { "eml1@xyz.com", "test@unit.org", "xyz@srv.it" })]
+        [InlineData(new[] { "sequence", "-sInlineData@iscool.org,test@unit.org,xyz@srv.it,another,the-last-one" }, new[] { "InlineData@iscool.org", "test@unit.org", "xyz@srv.it", "another", "the-last-one" })]
+        public void Parse_sequence_verb_with_separator_returns_verb_instance(string[] arguments, string[] expectedString)
+        {
+            // Fixture setup
+            var expected = new SequenceOptions { LongSequence = new long[] { }, StringSequence = expectedString };
+
+            // Exercize system 
+            var result = InstanceChooser.Choose(
+                new[] { typeof(AddOptions), typeof(CommitOptions), typeof(CloneOptions), typeof(SequenceOptions) },
+                arguments,
+                StringComparer.Ordinal,
+                CultureInfo.InvariantCulture);
+
+            // Verify outcome
+            Assert.IsType<SequenceOptions>(result.Value);
+            expected.ShouldBeEquivalentTo(result.Value);
+            // Teardown
+        }
     }
 }

--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -17,7 +17,12 @@ namespace CommandLine.Core
             CultureInfo parsingCulture)
         {
             return Choose(
-                (args, optionSpecs) => Tokenizer.Tokenize(args, name => NameLookup.Contains(name, optionSpecs, nameComparer)),
+                (args, optionSpecs) =>
+                {
+                    var tokens = Tokenizer.Tokenize(args, name => NameLookup.Contains(name, optionSpecs, nameComparer));
+                    var explodedTokens = Tokenizer.ExplodeOptionList(tokens, name => NameLookup.HavingSeparator(name, optionSpecs, nameComparer));
+                    return explodedTokens;
+                },
                 types,
                 arguments,
                 nameComparer,

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -170,12 +170,14 @@ namespace CommandLine
                 IEnumerable<OptionSpecification> optionSpecs,
                 ParserSettings settings)
         {
-            return settings.EnableDashDash
+            var tokens = settings.EnableDashDash
                 ? Tokenizer.PreprocessDashDash(
                         arguments,
                         args =>
                             Tokenizer.Tokenize(args, name => NameLookup.Contains(name, optionSpecs, settings.NameComparer)))
                 : Tokenizer.Tokenize(arguments, name => NameLookup.Contains(name, optionSpecs, settings.NameComparer));
+            var explodedTokens = Tokenizer.ExplodeOptionList(tokens, name => NameLookup.HavingSeparator(name, optionSpecs, settings.NameComparer));
+            return explodedTokens;
         }
 
         private static ParserResult<T> MakeParserResult<T>(Func<ParserResult<T>> parseFunc, ParserSettings settings)


### PR DESCRIPTION
While working with your great library, I found this bug where sequences are not splitted using the supplied separator in a verb scenario. Here is a suggested fix with some unit tests.