### PR TITLE
Fix issue with more than one array argument not being handled

### DIFF
--- a/src/CommandLine.Tests/Unit/Core/KeyValuePairHelperTests.cs
+++ b/src/CommandLine.Tests/Unit/Core/KeyValuePairHelperTests.cs
@@ -15,8 +15,8 @@ namespace CommandLine.Tests.Unit.Core
             var expected = new KeyValuePair<string, IEnumerable<string>>[] { };
 
             var result = KeyValuePairHelper.ForSequence(new Token[] { });
-
-            result.SequenceEqual(expected);
+        
+            AssertEqual(expected, result);
         }
 
         [Fact]
@@ -30,9 +30,37 @@ namespace CommandLine.Tests.Unit.Core
             var result = KeyValuePairHelper.ForSequence(new []
                 {
                     Token.Name("seq"), Token.Value("seq0"), Token.Value("seq1"), Token.Value("seq2") 
+                }).ToArray();
+
+            AssertEqual(expected, result);
+        }
+
+        [Fact]
+        public void Token_sequence_creates_a_KeyValuePair_sequence_for_multiple_sequences()
+        {
+            var expected = new[]
+                {
+                    new KeyValuePair<string, IEnumerable<string>>("seq1", new[] {"seq10", "seq11", "seq12"}),
+                    new KeyValuePair<string, IEnumerable<string>>("seq2", new[] {"seq20", "seq21"})
+                };
+
+            var result = KeyValuePairHelper.ForSequence(new[]
+                {
+                    Token.Name("seq1"), Token.Value("seq10"), Token.Value("seq11"), Token.Value("seq12"),
+                    Token.Name("seq2"), Token.Value("seq20"), Token.Value("seq21")
                 });
 
-            result.SequenceEqual(expected);
+            AssertEqual(expected, result);
+        }
+
+        private static void AssertEqual(IEnumerable<KeyValuePair<string, IEnumerable<string>>> expected, IEnumerable<KeyValuePair<string, IEnumerable<string>>> result)
+        {
+            Assert.Equal(expected.Count(), result.Count());
+            foreach (var value in expected.Zip(result, (e, r) => new { Expected = e, Result = r }))
+            {
+                Assert.Equal(value.Expected.Key, value.Result.Key);
+                Assert.Equal(value.Expected.Value, value.Result.Value);
+            }
         }
 
     }

--- a/src/CommandLine/Core/KeyValuePairHelper.cs
+++ b/src/CommandLine/Core/KeyValuePairHelper.cs
@@ -26,7 +26,7 @@ namespace CommandLine.Core
             return from t in tokens.Pairwise(
                 (f, s) =>
                         f.IsName()
-                            ? f.Text.ToKeyValuePair(tokens.SkipWhile(t => t.Equals(f)).TakeWhile(v => v.IsValue()).Select(x => x.Text).ToArray())
+                            ? f.Text.ToKeyValuePair(tokens.SkipWhile(t => !t.Equals(f)).SkipWhile(t => t.Equals(f)).TakeWhile(v => v.IsValue()).Select(x => x.Text).ToArray())
                             : string.Empty.ToKeyValuePair())
                    where t.Key.Length > 0 && t.Value.Any()
                    select t;


### PR DESCRIPTION
Only a single array argument is ever parsed correctly. This is a fix for this issue along with an additional unit test. Also included are modifications for the other tests is KeyValuePairHelperTests.cs as the tests were not actually asserting on anything. Assert.Equals was not suitable as this would fail when comparing KeyValuePair objects with references to different collections, even thought the collections had the same values. Don't know if you like the style of the general AssertEquals method or would rather see more specific asserts in-line in the test. Let me know if you'd like this changed. Cheers and thanks for the library.