### PR TITLE
Correct sequence longer than max error message

### DIFF
--- a/src/CommandLine/Text/SentenceBuilder.cs
+++ b/src/CommandLine/Text/SentenceBuilder.cs
@@ -101,7 +101,7 @@ namespace CommandLine.Text
                                     var seqOutRange = ((SequenceOutOfRangeError)error);
                                     return seqOutRange.NameInfo == NameInfo.EmptyName
                                                ? "A sequence value not bound to option name is defined with few items than required."
-                                               : "A sequence option '" + seqOutRange.NameInfo.NameText + "' is defined with few items than required.";
+                                               : "A sequence option '" + seqOutRange.NameInfo.NameText + "' is defined with fewer or more items than required.";
                                 case ErrorType.BadVerbSelectedError:
                                     return "Verb '" + ((BadVerbSelectedError)error).Token + "' is not recognized.";
                                 case ErrorType.NoVerbSelectedError:


### PR DESCRIPTION
If a sequence had too many items the error message said that it had too few.