### PR TITLE
Repeated options test throws an exception when default parser is used

### DIFF
--- a/src/CommandLine/Text/SentenceBuilder.cs
+++ b/src/CommandLine/Text/SentenceBuilder.cs
@@ -130,6 +130,9 @@ namespace CommandLine.Text
                                     return "Verb '".JoinTo(((BadVerbSelectedError)error).Token, "' is not recognized.");
                                 case ErrorType.NoVerbSelectedError:
                                     return "No verb selected.";
+                                case ErrorType.RepeatedOptionError:
+                                    return "Option '".JoinTo(((RepeatedOptionError)error).NameInfo.NameText,
+                                        "' is defined multiple times.");
                             }
                             throw new InvalidOperationException();
                         };

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -79,6 +79,20 @@ namespace CommandLine.Tests.Unit
         }
 
         [Fact]
+        public void Parse_repeated_options_with_default_parser()
+        {
+            // Fixture setup
+            var sut = Parser.Default;
+
+            // Exercize system
+            var result = sut.ParseArguments<FakeOptionsWithSwitches>(new[] { "-i", "-i", "-o", "file" });
+
+            // Verify outcome
+            Assert.IsType<NotParsed<FakeOptionsWithSwitches>>(result);
+            // Teardown
+        }
+
+        [Fact]
         public void Parse_options_with_double_dash()
         {
             // Fixture setup
@@ -141,6 +155,22 @@ namespace CommandLine.Tests.Unit
             // Verify outcome
             Assert.IsType<CloneOptions>(((Parsed<object>)result).Value);
             ((Parsed<object>)result).Value.ShouldBeEquivalentTo(expectedOptions, o => o.RespectingRuntimeTypes());
+            // Teardown
+        }
+
+        [Fact]
+        public void Parse_repeated_options_with_default_parser_in_verbs_scenario()
+        {
+            // Fixture setup
+            var sut = Parser.Default;
+
+            // Exercize system
+            var result = sut.ParseArguments(
+                new[] { "clone", "-q", "-q", "http://gsscoder.github.com/", "http://yes-to-nooo.github.com/" },
+                typeof(AddOptions), typeof(CommitOptions), typeof(CloneOptions));
+
+            // Verify outcome
+            Assert.IsType<NotParsed<object>>(result);
             // Teardown
         }
 


### PR DESCRIPTION
@gsscoder, it seems that when using the default parser (ie with a defined `HelpWriter`), if you have a parse error, all kind of errors are not well handled.
For instance, if you get a `RepeatedOptionError`, it just throws an `InvalidOperationException`, making hard to understand what went wrong. May be some other kind of errors are also to be fixed.
Let me know if you want some help on this one.