### PR TITLE
Added Windows Style LongName ("/") to Options along with the required…

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -8,6 +8,7 @@ using CommandLine.Core;
 using CommandLine.Text;
 using CSharpx;
 using RailwaySharp.ErrorHandling;
+using CommandLine.Infrastructure;
 
 namespace CommandLine
 {
@@ -157,6 +158,28 @@ namespace CommandLine
                     settings.ParsingCulture,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);
+        }
+
+        public ParserResult<object> ParseArguments(IEnumerable<string> args, IEnumerable<Type> types, bool useWinStyleOptions = true)
+        {
+            return ParseArguments(ParserExtensions.ConvertWindowsStyleOptions(args), types.ToArray());
+        }
+
+        /// 
+        /// <summary>
+        /// Parses a string array of command line arguments constructing values in an instance of type <typeparamref name="T"/>.
+        /// Grammar rules are defined decorating public properties with appropriate attributes.
+        /// </summary>
+        /// <typeparam name="T">Type of the target instance built with parsed value.</typeparam>
+        /// <param name="args">A <see cref="System.String"/> array of command line arguments, normally supplied by application entry point.</param>
+        /// <param name="useWinStyleOptions">Allows using '/' instead of '--' for option long names</param>
+        /// <returns>A <see cref="CommandLine.ParserResult{T}"/> containing an instance of type <typeparamref name="T"/> with parsed values
+        /// and a sequence of <see cref="CommandLine.Error"/>.</returns>
+        /// <exception cref="System.ArgumentNullException">Thrown if one or more arguments are null.</exception>
+        public ParserResult<T> ParseArguments<T>(IEnumerable<string> args, bool useWinStyleOptions = true)
+        {
+            if (args == null) throw new ArgumentNullException("args");
+            return ParseArguments<T>(ParserExtensions.ConvertWindowsStyleOptions(args));
         }
 
         /// <summary>

--- a/src/CommandLine/ParserExtensions.cs
+++ b/src/CommandLine/ParserExtensions.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace CommandLine
 {
@@ -422,5 +423,20 @@ namespace CommandLine
             return parser.ParseArguments(args, new[] { typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6), typeof(T7), typeof(T8),
                 typeof(T9), typeof(T10), typeof(T11), typeof(T12), typeof(T13), typeof(T14), typeof(T15), typeof(T16) });
         }
+
+
+        internal static IEnumerable<string> ConvertWindowsStyleOptions(IEnumerable<string> args)
+        {
+            var longNameStock = "--";
+            var longNameWin = "/";
+
+            return args.Any() ?
+                args.Select(a =>
+                    a.StartsWith(longNameWin)
+                    ? a.Replace(longNameWin, longNameStock)
+                    : a) : args;
+        }
+
+
     }
 }


### PR DESCRIPTION
… unit tests. I have refrained from altering the core logic. Instead I added two overloaded methods for Parser.ParseArguments(...) with an additional optional parameter "useWinStyleOptions" which is set to true per default. From there on I simply check all arguments for the win style flag ("/") and replace them with the stock double dashes ("--"). The result I pass to the original ParseArguments-Methods.

While as a personal preference I take unix style options over windows style options every day but there is a remote service I am using that is among other things capable of executing applications. I cant easily change the service - its fairly old and written in vb.net - but I checked the implementation. Turns out its capable of interpreting windows style options and passing that to the application it starts. So there you go.

There might be others in a similar situation to whom this could be a possible solution.

Please review the code.