### PR TITLE
Error with Usage attribute (UnParser)

### DIFF
--- a/src/CommandLine/UnParserExtensions.cs
+++ b/src/CommandLine/UnParserExtensions.cs
@@ -142,17 +142,12 @@ namespace CommandLine
                 ? builder.Append('-').Append(string.Join(string.Empty, shortSwitches.Select(
                     info => ((OptionSpecification)info.Specification).ShortName).ToArray())).Append(' ')
                 : builder;
-            builder
-                .TrimEndIfMatchWhen(!optSpecs.Any() || builder.TrailingSpaces() > 1, ' ');
             optSpecs.ForEach(
                 opt =>
                     builder
-                        .TrimEndIfMatchWhen(builder.TrailingSpaces() > 1, ' ')
                         .Append(FormatOption((OptionSpecification)opt.Specification, opt.Value, settings))
                         .Append(' ')
                 );
-            builder
-                .TrimEndIfMatchWhen(!valSpecs.Any() || builder.TrailingSpaces() > 1, ' ');
             valSpecs.ForEach(
                 val => builder.Append(FormatValue(val.Specification, val.Value)).Append(' '));
 
@@ -175,7 +170,7 @@ namespace CommandLine
                     var e = ((IEnumerable)value).GetEnumerator();
                     while (e.MoveNext())
                         builder.Append(format(e.Current)).Append(sep);
-                    builder.TrimEndIfMatch(' ');
+                    builder.TrimEndIfMatch(sep);
                     break;
             }
             return builder.ToString();
@@ -216,7 +211,7 @@ namespace CommandLine
                 new StringBuilder(longName
                     ? "--".JoinTo(optionSpec.LongName)
                     : "-".JoinTo(optionSpec.ShortName))
-                        .AppendIf(longName && settings.UseEqualToken && optionSpec.ConversionType != typeof(bool), "=", " ")
+                        .AppendWhen(optionSpec.TargetType != TargetType.Switch, longName && settings.UseEqualToken ? "=" : " ")
                     .ToString();
         }
 

--- a/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
@@ -58,6 +58,12 @@ namespace CommandLine.Tests.Fakes
         [Option('e', "errs", HelpText = "Log errors.")]
         public bool LogError { get; set; }
 
+        [Option('l', Separator = ',', HelpText = "List.")]
+        public IEnumerable<int> List { get; set; }
+
+        [Value(0, HelpText = "Value.")]
+        public string Value { get; set; }
+
         [Usage(ApplicationAlias = "mono testapp.exe")]
         public static IEnumerable<Example> Examples
         {
@@ -66,6 +72,8 @@ namespace CommandLine.Tests.Fakes
                 yield return new Example("Normal scenario", new Options_With_Usage_Attribute { InputFile = "file.bin", OutputFile = "out.bin" });
                 yield return new Example("Logging warnings", UnParserSettings.WithGroupSwitchesOnly() , new Options_With_Usage_Attribute { InputFile = "file.bin", LogWarning = true });
                 yield return new Example("Logging errors", new[] { UnParserSettings.WithGroupSwitchesOnly(), UnParserSettings.WithUseEqualTokenOnly() }, new Options_With_Usage_Attribute { InputFile = "file.bin", LogError = true });
+                yield return new Example("List", new Options_With_Usage_Attribute { List = new[] { 1, 2 } });
+                yield return new Example("Value", new Options_With_Usage_Attribute { Value = "value" });
             }
         }
     }
@@ -134,6 +142,7 @@ namespace CommandLine.Tests.Fakes
         {
             get
             {
+                yield return new Example("Basic cloning", new Clone_Verb_With_Usage_Attribute { Urls = new[] { "https://github.com/gsscoder/csharpx" } });
                 yield return new Example("Cloning quietly", new Clone_Verb_With_Usage_Attribute { Quiet = true, Urls = new[] { "https://github.com/gsscoder/railwaysharp" } });
                 yield return new Example("Cloning without hard links", new Clone_Verb_With_Usage_Attribute { NoHardLinks = true, Urls = new[] { "https://github.com/gsscoder/csharpx" } });
             }

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -460,16 +460,18 @@ namespace CommandLine.Tests.Unit
             lines[2].ShouldBeEquivalentTo("ERROR(S):");
             lines[3].ShouldBeEquivalentTo("Option 'badoption' is unknown.");
             lines[4].ShouldBeEquivalentTo("USAGE:");
-            lines[5].ShouldBeEquivalentTo("Cloning quietly:");
-            lines[6].ShouldBeEquivalentTo("git clone --quiet https://github.com/gsscoder/railwaysharp");
-            lines[7].ShouldBeEquivalentTo("Cloning without hard links:");
-            lines[8].ShouldBeEquivalentTo("git clone --no-hardlinks https://github.com/gsscoder/csharpx");
-            lines[9].ShouldBeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
-            lines[10].ShouldBeEquivalentTo("filesystem by copying files.");
-            lines[11].ShouldBeEquivalentTo("-q, --quiet       Suppress summary message.");
-            lines[12].ShouldBeEquivalentTo("--help            Display this help screen.");
-            lines[13].ShouldBeEquivalentTo("--version         Display version information.");
-            lines[14].ShouldBeEquivalentTo("URLS (pos. 0)     A list of url(s) to clone.");
+            lines[5].ShouldBeEquivalentTo("Basic cloning:");
+            lines[6].ShouldBeEquivalentTo("git clone https://github.com/gsscoder/csharpx");
+            lines[7].ShouldBeEquivalentTo("Cloning quietly:");
+            lines[8].ShouldBeEquivalentTo("git clone --quiet https://github.com/gsscoder/railwaysharp");
+            lines[9].ShouldBeEquivalentTo("Cloning without hard links:");
+            lines[10].ShouldBeEquivalentTo("git clone --no-hardlinks https://github.com/gsscoder/csharpx");
+            lines[11].ShouldBeEquivalentTo("--no-hardlinks    Optimize the cloning process from a repository on a local");
+            lines[12].ShouldBeEquivalentTo("filesystem by copying files.");
+            lines[13].ShouldBeEquivalentTo("-q, --quiet       Suppress summary message.");
+            lines[14].ShouldBeEquivalentTo("--help            Display this help screen.");
+            lines[15].ShouldBeEquivalentTo("--version         Display version information.");
+            lines[16].ShouldBeEquivalentTo("URLS (pos. 0)     A list of url(s) to clone.");
 
             // Teardown
         }

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -387,6 +387,10 @@ namespace CommandLine.Tests.Unit.Text
             lines[4].ShouldBeEquivalentTo("Logging errors:");
             lines[5].ShouldBeEquivalentTo("  mono testapp.exe -e --input file.bin");
             lines[6].ShouldBeEquivalentTo("  mono testapp.exe --errs --input=file.bin");
+            lines[7].ShouldBeEquivalentTo("List:");
+            lines[8].ShouldBeEquivalentTo("  mono testapp.exe -l 1,2");
+            lines[9].ShouldBeEquivalentTo("Value:");
+            lines[10].ShouldBeEquivalentTo("  mono testapp.exe value");
         }
 
         [Fact]
@@ -418,13 +422,19 @@ namespace CommandLine.Tests.Unit.Text
             lines[9].ShouldBeEquivalentTo("Logging errors:");
             lines[10].ShouldBeEquivalentTo("mono testapp.exe -e --input file.bin");
             lines[11].ShouldBeEquivalentTo("mono testapp.exe --errs --input=file.bin");
-            lines[12].ShouldBeEquivalentTo("-i, --input     Set input file.");
-            lines[13].ShouldBeEquivalentTo("-i, --output    Set output file.");
-            lines[14].ShouldBeEquivalentTo("--verbose       Set verbosity level.");
-            lines[15].ShouldBeEquivalentTo("-w, --warns     Log warnings.");
-            lines[16].ShouldBeEquivalentTo("-e, --errs      Log errors.");
-            lines[17].ShouldBeEquivalentTo("--help          Display this help screen.");
-            lines[18].ShouldBeEquivalentTo("--version       Display version information.");
+            lines[12].ShouldBeEquivalentTo("List:");
+            lines[13].ShouldBeEquivalentTo("mono testapp.exe -l 1,2");
+            lines[14].ShouldBeEquivalentTo("Value:");
+            lines[15].ShouldBeEquivalentTo("mono testapp.exe value");
+            lines[16].ShouldBeEquivalentTo("-i, --input     Set input file.");
+            lines[17].ShouldBeEquivalentTo("-i, --output    Set output file.");
+            lines[18].ShouldBeEquivalentTo("--verbose       Set verbosity level.");
+            lines[19].ShouldBeEquivalentTo("-w, --warns     Log warnings.");
+            lines[20].ShouldBeEquivalentTo("-e, --errs      Log errors.");
+            lines[21].ShouldBeEquivalentTo("-l              List.");
+            lines[22].ShouldBeEquivalentTo("--help          Display this help screen.");
+            lines[23].ShouldBeEquivalentTo("--version       Display version information.");
+            lines[24].ShouldBeEquivalentTo("value pos. 0    Value.");
 
             // Teardown
         }


### PR DESCRIPTION
@gsscoder, I started using your new `Usage` attribute and found 2 bugs:
- with list, if the separator is not a space, `UnParser` appends an extra separator at the end of the list (eg `mono testapp.exe -l 1,2,` instead of `mono testapp.exe -l 1,2`)
- in verb scenario and with only a value (ie no option): `UnParser` remove to many spaces and the result is that the verb and the value have no space between (ie `git clonehttps://github.com/gsscoder/csharpx` instead of `git clone https://github.com/gsscoder/csharpx`)

Here is a fix for both issues and related unit tests as usual.
What do you think?