### PR TITLE
Fixes reversed parameters for new NameInfo call in FromOptionSpecification

### DIFF
--- a/src/CommandLine/Core/NameExtensions.cs
+++ b/src/CommandLine/Core/NameExtensions.cs
@@ -16,8 +16,8 @@ namespace CommandLine.Core
         public static NameInfo FromOptionSpecification(this OptionSpecification specification)
         {
             return new NameInfo(
-                specification.LongName,
-                specification.ShortName);
+                specification.ShortName,
+                specification.LongName);
         }
 
         public static NameInfo FromSpecification(this Specification specification)

--- a/tests/CommandLine.Tests/Unit/Core/NameLookupTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/NameLookupTests.cs
@@ -27,5 +27,25 @@ namespace CommandLine.Tests.Unit.Core
 
             // Teardown
         }
+
+        [Fact]
+        public void Get_name_from_option_specification()
+        {
+            const string ShortName = "s";
+            const string LongName = "long";
+
+            // Fixture setup
+            var expected = new NameInfo(ShortName, LongName);
+            var spec = new OptionSpecification(ShortName, LongName, false, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(), '.', null, string.Empty, string.Empty, new List<string>(), typeof(IEnumerable<string>), TargetType.Sequence);
+
+            // Exercize system
+            var result = spec.FromOptionSpecification();
+
+            // Verify outcome
+            expected.ShouldBeEquivalentTo(result);
+
+            // Teardown
+        }
+
     }
 }


### PR DESCRIPTION
The ShortName/LongName parameters are reversed when creating a new NameInfo in FromOptionSpecification. 