### PR TITLE
Allow Enum conversion to occur via TypeConverter (system)

### DIFF
--- a/src/CommandLine/Core/TypeConverter.cs
+++ b/src/CommandLine/Core/TypeConverter.cs
@@ -96,20 +96,15 @@ namespace CommandLine.Core
 
         private static object ToEnum(this string value, Type conversionType)
         {
-            object parsedValue;
             try
             {
-                parsedValue = Enum.Parse(conversionType, value);
+                var conv = System.ComponentModel.TypeDescriptor.GetConverter(conversionType);
+                return (conv.ConvertFrom(value));
             }
-            catch (ArgumentException)
+            catch (NotSupportedException e)
             {
                 throw new FormatException();
             }
-            if (Enum.IsDefined(conversionType, parsedValue))
-            {
-                return parsedValue;
-            }
-            throw new FormatException();
         }
     }
 }


### PR DESCRIPTION
Patch is so that default handling for Enums is implemented via TypeCoverter.
This means that case concerns are handled and can be overridden via the TypeConverter attribute.

This patch also removes a redundant IsDefined check in the original code.
