### PR TITLE
Removed where T : new()

### DIFF
--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -114,7 +114,6 @@ namespace CommandLine
         /// and a sequence of <see cref="CommandLine.Error"/>.</returns>
         /// <exception cref="System.ArgumentNullException">Thrown if one or more arguments are null.</exception>
         public ParserResult<T> ParseArguments<T>(Func<T> factory, IEnumerable<string> args)
-            where T : new()
         {
             if (factory == null) throw new ArgumentNullException("factory");
             if (!typeof(T).IsMutable()) throw new ArgumentException("factory");


### PR DESCRIPTION
Removed where T : new() from the ParseArguments<T> factory method as it
shouldn't be required if convention is followed of only mutable classes
required a default constructor, and immutable classes are supported and
do not have this requirement, so the new() restriction is blocking
immutable classes which should typically not have a default constructor.

This resolves #310
