### PR TITLE
Implemented Hidden Verbs, Options and Values

### DIFF
--- a/src/CommandLine/BaseAttribute.cs
+++ b/src/CommandLine/BaseAttribute.cs
@@ -123,5 +123,14 @@ namespace CommandLine
                 metaValue = value;
             }
         }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether a command line option is visible in the help text.
+        /// </summary>
+        public bool Hidden
+        {
+            get;
+            set;
+        }
     }
 }

--- a/src/CommandLine/Core/OptionSpecification.cs
+++ b/src/CommandLine/Core/OptionSpecification.cs
@@ -16,8 +16,8 @@ namespace CommandLine.Core
 
         public OptionSpecification(string shortName, string longName, bool required, string setName, Maybe<int> min, Maybe<int> max,
             char separator, Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
-            Type conversionType, TargetType targetType)
-            : base(SpecificationType.Option, required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType)
+            Type conversionType, TargetType targetType, bool hidden = false)
+            : base(SpecificationType.Option, required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
         {
             this.shortName = shortName;
             this.longName = longName;
@@ -40,13 +40,14 @@ namespace CommandLine.Core
                 attribute.MetaValue,
                 enumValues,
                 conversionType,
-                conversionType.ToTargetType());
+                conversionType.ToTargetType(),
+                attribute.Hidden);
         }
 
-        public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue)
+        public static OptionSpecification NewSwitch(string shortName, string longName, bool required, string helpText, string metaValue, bool hidden = false)
         {
             return new OptionSpecification(shortName, longName, required, string.Empty, Maybe.Nothing<int>(), Maybe.Nothing<int>(),
-                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch);
+                '\0', Maybe.Nothing<object>(), helpText, metaValue, Enumerable.Empty<string>(), typeof(bool), TargetType.Switch, hidden);
         }
 
         public string ShortName

--- a/src/CommandLine/Core/Specification.cs
+++ b/src/CommandLine/Core/Specification.cs
@@ -25,6 +25,7 @@ namespace CommandLine.Core
     {
         private readonly SpecificationType tag;
         private readonly bool required;
+        private readonly bool hidden;
         private readonly Maybe<int> min;
         private readonly Maybe<int> max;
         private readonly Maybe<object> defaultValue;
@@ -37,7 +38,7 @@ namespace CommandLine.Core
 
         protected Specification(SpecificationType tag, bool required, Maybe<int> min, Maybe<int> max,
             Maybe<object> defaultValue, string helpText, string metaValue, IEnumerable<string> enumValues,
-            Type conversionType, TargetType targetType)
+            Type conversionType, TargetType targetType, bool hidden = false)
         {
             this.tag = tag;
             this.required = required;
@@ -49,6 +50,7 @@ namespace CommandLine.Core
             this.helpText = helpText;
             this.metaValue = metaValue;
             this.enumValues = enumValues;
+            this.hidden = hidden;
         }
 
         public SpecificationType Tag 
@@ -99,6 +101,11 @@ namespace CommandLine.Core
         public TargetType TargetType
         {
             get { return targetType; }
+        }
+
+        public bool Hidden
+        {
+            get { return hidden; }
         }
 
         public static Specification FromProperty(PropertyInfo property)

--- a/src/CommandLine/Core/SpecificationExtensions.cs
+++ b/src/CommandLine/Core/SpecificationExtensions.cs
@@ -33,7 +33,8 @@ namespace CommandLine.Core
                 specification.MetaValue,
                 specification.EnumValues,
                 specification.ConversionType,
-                specification.TargetType);
+                specification.TargetType,
+                specification.Hidden);
         }
 
         public static string UniqueName(this OptionSpecification specification)

--- a/src/CommandLine/Core/ValueSpecification.cs
+++ b/src/CommandLine/Core/ValueSpecification.cs
@@ -13,8 +13,8 @@ namespace CommandLine.Core
 
         public ValueSpecification(int index, string metaName, bool required, Maybe<int> min, Maybe<int> max, Maybe<object> defaultValue,
             string helpText, string metaValue, IEnumerable<string> enumValues,
-            Type conversionType, TargetType targetType)
-            : base(SpecificationType.Value, required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType)
+            Type conversionType, TargetType targetType, bool hidden = false)
+            : base(SpecificationType.Value, required, min, max, defaultValue, helpText, metaValue, enumValues, conversionType, targetType, hidden)
         {
             this.index = index;
             this.metaName = metaName;
@@ -33,7 +33,8 @@ namespace CommandLine.Core
                 attribute.MetaValue,
                 enumValues,
                 conversionType,
-                conversionType.ToTargetType());
+                conversionType.ToTargetType(),
+                attribute.Hidden);
         }
 
         public int Index

--- a/src/CommandLine/Core/Verb.cs
+++ b/src/CommandLine/Core/Verb.cs
@@ -10,14 +10,16 @@ namespace CommandLine.Core
     {
         private readonly string name;
         private readonly string helpText;
+        private readonly bool hidden;
 
-        public Verb(string name, string helpText)
+        public Verb(string name, string helpText, bool hidden = false)
         {
             if (name == null) throw new ArgumentNullException("name");
             if (helpText == null) throw new ArgumentNullException("helpText");
 
             this.name = name;
             this.helpText = helpText;
+            this.hidden = hidden;
         }
 
         public string Name
@@ -30,11 +32,17 @@ namespace CommandLine.Core
             get { return helpText; }
         }
 
+        public bool Hidden
+        {
+            get { return hidden; }
+        }
+
         public static Verb FromAttribute(VerbAttribute attribute)
         {
             return new Verb(
                 attribute.Name,
-                attribute.HelpText
+                attribute.HelpText,
+                attribute.Hidden
                 );
         }
 

--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -683,7 +683,8 @@ namespace CommandLine.Text
                             verbTuple.Item1.Name,
                             false,
                             verbTuple.Item1.HelpText,
-                            string.Empty)).Concat(new[] { MakeHelpEntry(), MakeVersionEntry() });
+                            string.Empty,
+                            verbTuple.Item1.Hidden)).Concat(new[] { MakeHelpEntry(), MakeVersionEntry() });
         }
 
         private HelpText AddOptionsImpl(
@@ -711,7 +712,8 @@ namespace CommandLine.Text
                 "help",
                 false,
                 sentenceBuilder.HelpCommandText(AddDashesToOption),
-                string.Empty);
+                string.Empty,
+                false);
         }
 
         private OptionSpecification MakeVersionEntry()
@@ -721,7 +723,8 @@ namespace CommandLine.Text
                 "version",
                 false,
                 sentenceBuilder.VersionCommandText(AddDashesToOption),
-                string.Empty);
+                string.Empty,
+                false);
         }
 
         private HelpText AddPreOptionsLine(string value, int maximumLength)
@@ -733,6 +736,9 @@ namespace CommandLine.Text
 
         private HelpText AddOption(string requiredWord, int maxLength, Specification specification, int widthOfHelpText)
         {
+            if (specification.Hidden)
+                return this;
+
             optionsHelp.Append("  ");
             var name = new StringBuilder(maxLength)
                 .BimapIf(
@@ -841,13 +847,15 @@ namespace CommandLine.Text
         {
             return specifications.Aggregate(0,
                 (length, spec) =>
-                    {
-                        var specLength = spec.Tag == SpecificationType.Option
+                {
+                    if (spec.Hidden)
+                        return length;
+                    var specLength = spec.Tag == SpecificationType.Option
                             ? GetMaxOptionLength((OptionSpecification)spec)
                             : GetMaxValueLength((ValueSpecification)spec);
 
-                        return Math.Max(length, specLength);
-                    });
+                    return Math.Max(length, specLength);
+                });
         }
 
 

--- a/src/CommandLine/VerbAttribute.cs
+++ b/src/CommandLine/VerbAttribute.cs
@@ -35,6 +35,15 @@ namespace CommandLine
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether a command line verb is visible in the help text.
+        /// </summary>
+        public bool Hidden
+        {
+            get;
+            set;
+        }
+
+        /// <summary>
         /// Gets or sets a short description of this command line option. Usually a sentence summary. 
         /// </summary>
         public string HelpText

--- a/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Help_Fakes.cs
@@ -2,6 +2,7 @@
 
 using System.Collections.Generic;
 using CommandLine.Text;
+using Microsoft.FSharp.Collections;
 
 namespace CommandLine.Tests.Fakes
 {
@@ -12,6 +13,9 @@ namespace CommandLine.Tests.Fakes
 
         [Option("input-file")]
         public string FileName { get; set; }
+
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
     }
 
     class Simple_Options_With_HelpText_Set
@@ -21,6 +25,9 @@ namespace CommandLine.Tests.Fakes
 
         [Option('i', "input-file", Required = true, HelpText = "Specify input file to be processed.")]
         public string FileName { get; set; }
+
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
     }
 
     class Simple_Options_With_HelpText_Set_To_Long_Description
@@ -30,6 +37,9 @@ namespace CommandLine.Tests.Fakes
 
         [Option("input-file", HelpText = "This is a very long description of the Input File argument that gets passed in.  It should  be passed in as a string.")]
         public string FileName { get; set; }
+
+        [Option("secert-option", Hidden =  true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
     }
 
     class Simple_Options_With_HelpText_Set_To_Long_Description_Without_Spaces
@@ -39,6 +49,9 @@ namespace CommandLine.Tests.Fakes
 
         [Option("input-file", HelpText = "Before 012345678901234567890123456789 After")]
         public string FileName { get; set; }
+
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
     }
 
     class Options_With_Usage_Attribute
@@ -64,6 +77,9 @@ namespace CommandLine.Tests.Fakes
         [Value(0, HelpText = "Value.")]
         public string Value { get; set; }
 
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
+
         [Usage(ApplicationAlias = "mono testapp.exe")]
         public static IEnumerable<Example> Examples
         {
@@ -76,6 +92,16 @@ namespace CommandLine.Tests.Fakes
                 yield return new Example("Value", new Options_With_Usage_Attribute { Value = "value" });
             }
         }
+    }
+
+    [Verb("secert", Hidden = true, HelpText = "This is a secert hidden verb that should never be visible to the user via help text.")]
+    public class Secert_Verb
+    {
+        [Option('f', "force", SetName = "mode-f", HelpText = "Allow adding otherwise ignored files.")]
+        public bool Force { get; set; }
+
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
     }
 
     [Verb("add", HelpText = "Add file contents to the index.")]
@@ -91,6 +117,9 @@ namespace CommandLine.Tests.Fakes
 
         [Value(0)]
         public string FileName { get; set; }
+
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
 
         [Usage(ApplicationAlias = "git")]
         public static IEnumerable<Example> Examples
@@ -112,6 +141,9 @@ namespace CommandLine.Tests.Fakes
         [Option("amend", HelpText = "Used to amend the tip of the current branch.")]
         public bool Amend { get; set; }
 
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
+
         [Usage(ApplicationAlias = "git")]
         public static IEnumerable<Example> Examples
         {
@@ -132,6 +164,9 @@ namespace CommandLine.Tests.Fakes
         [Option('q', "quiet",
             HelpText = "Suppress summary message.")]
         public bool Quiet { get; set; }
+
+        [Option("secert-option", Hidden = true, HelpText = "This is a description for a secert hidden option that should never be visibile to the user via help text.")]
+        public string SecertOption { get; set; }
 
         [Value(0, MetaName = "URLS",
             HelpText = "A list of url(s) to clone.")]

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -492,6 +492,91 @@ namespace CommandLine.Tests.Unit
             // Teardown
         }
 
+         [Fact]
+        public void Properly_formatted_help_screen_is_displayed_when_there_is_a_hidden_verb()
+        {
+            // Fixture setup
+            var help = new StringWriter();
+            var sut = new Parser(config => config.HelpWriter = help);
+
+            // Exercize system
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { });
+            var result = help.ToString();
+            
+            // Verify outcome
+            var lines = result.ToNotEmptyLines().TrimStringArray();
+            lines[0].Should().StartWithEquivalent("CommandLine");
+            lines[1].ShouldBeEquivalentTo("Copyright (c) 2005 - 2015 Giacomo Stelluti Scala");
+            lines[2].ShouldBeEquivalentTo("ERROR(S):");
+            lines[3].ShouldBeEquivalentTo("No verb selected.");
+            lines[4].ShouldBeEquivalentTo("add        Add file contents to the index.");
+            lines[5].ShouldBeEquivalentTo("help       Display more information on a specific command.");
+            lines[6].ShouldBeEquivalentTo("version    Display version information.");
+
+            // Teardown
+        }
+
+        [Fact]
+        public void Properly_formatted_help_screen_is_displayed_when_there_is_a_hidden_verb_selected_usage_displays_with_hidden_option()
+        {
+            // Fixture setup
+            var help = new StringWriter();
+            var sut = new Parser(config => config.HelpWriter = help);
+
+            // Exercize system
+            sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { "secert", "--help" });
+            var result = help.ToString();
+            
+            // Verify outcome
+            var lines = result.ToNotEmptyLines().TrimStringArray();
+            lines[0].Should().StartWithEquivalent("CommandLine");
+            lines[1].ShouldBeEquivalentTo("Copyright (c) 2005 - 2015 Giacomo Stelluti Scala");
+            lines[2].ShouldBeEquivalentTo("-f, --force    Allow adding otherwise ignored files.");
+            lines[3].ShouldBeEquivalentTo("--help         Display this help screen.");
+            lines[4].ShouldBeEquivalentTo("--version      Display version information.");
+
+            // Teardown
+        }
+        
+        [Fact]
+        public void Parse_options_when_given_hidden_verb()
+        {
+            // Fixture setup
+            var expectedOptions = new Secert_Verb { Force = true, SecertOption = null};
+            var help = new StringWriter();
+            var sut = new Parser(config => config.HelpWriter = help);
+
+            // Exercize system
+            var result = sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { "secert", "--force" });
+            
+
+            // Verify outcome
+            result.Tag.ShouldBeEquivalentTo(ParserResultType.Parsed);
+            result.GetType().Should().Be<Parsed<object>>();
+            result.TypeInfo.Current.Should().Be<Secert_Verb>();
+            ((Parsed<object>)result).Value.ShouldBeEquivalentTo(expectedOptions, o => o.RespectingRuntimeTypes());
+            // Teardown
+        }
+
+        [Fact]
+        public void Parse_options_when_given_hidden_verb_with_hidden_option()
+        {
+            // Fixture setup
+            var expectedOptions = new Secert_Verb { Force = true, SecertOption = "shhh" };
+            var help = new StringWriter();
+            var sut = new Parser(config => config.HelpWriter = help);
+
+            // Exercize system
+            var result = sut.ParseArguments<Secert_Verb, Add_Verb_With_Usage_Attribute>(new string[] { "secert", "--force", "--secert-option", "shhh" });
+            
+            // Verify outcome
+            result.Tag.ShouldBeEquivalentTo(ParserResultType.Parsed);
+            result.GetType().Should().Be<Parsed<object>>();
+            result.TypeInfo.Current.Should().Be<Secert_Verb>();
+            ((Parsed<object>)result).Value.ShouldBeEquivalentTo(expectedOptions, o => o.RespectingRuntimeTypes());
+            // Teardown
+        }
+
         [Fact]
         public void Specific_verb_help_screen_should_be_displayed_regardless_other_argument()
         {

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -152,7 +152,7 @@ namespace CommandLine.Tests.Unit.Text
             lines[6].ShouldBeEquivalentTo("                Help Text.");
             // Teardown
         }
-
+        
 
 
         [Fact]
@@ -161,7 +161,6 @@ namespace CommandLine.Tests.Unit.Text
             // Fixture setup
             // Exercize system 
             var sut = new HelpText(new HeadingInfo("CommandLine.Tests.dll", "1.9.4.131")) { MaximumDisplayWidth = 100} ;
-            //sut.MaximumDisplayWidth = 100;
             sut.AddOptions(
                 new NotParsed<Simple_Options_With_HelpText_Set_To_Long_Description>(
                     TypeInfo.Create(typeof(Simple_Options_With_HelpText_Set_To_Long_Description)),
@@ -172,6 +171,25 @@ namespace CommandLine.Tests.Unit.Text
             lines[2].ShouldBeEquivalentTo("  v, verbose    This is the description of the verbosity to test out the wrapping capabilities of "); //"The first line should have the arguments and the start of the Help Text.");
             //string formattingMessage = "Beyond the second line should be formatted as though it's in a column.";
             lines[3].ShouldBeEquivalentTo("                the Help Text.");
+            // Teardown
+        }
+
+        [Fact]
+        public void When_help_text_has_hidden_option_it_should_not_be_added_to_help_text_output()
+        {
+            // Fixture setup
+            // Exercize system 
+            var sut = new HelpText(new HeadingInfo("CommandLine.Tests.dll", "1.9.4.131"));
+            sut.AddOptions(
+                new NotParsed<Simple_Options_With_HelpText_Set_To_Long_Description>(
+                    TypeInfo.Create(typeof(Simple_Options_With_HelpText_Set_To_Long_Description)),
+                    Enumerable.Empty<Error>()));
+
+            // Verify outcome
+            var lines = sut.ToString().Split(new[] { Environment.NewLine }, StringSplitOptions.None);
+            lines[2].ShouldBeEquivalentTo("  v, verbose    This is the description of the verbosity to test out the "); //"The first line should have the arguments and the start of the Help Text.");
+            //string formattingMessage = "Beyond the second line should be formatted as though it's in a column.";
+            lines[3].ShouldBeEquivalentTo("                wrapping capabilities of the Help Text.");
             // Teardown
         }
 
@@ -458,7 +476,7 @@ namespace CommandLine.Tests.Unit.Text
             var helpText = HelpText.AutoBuild(fakeResult);
 
             // Verify outcome
-            var text = helpText.ToString();
+            var text = helpText.ToString();            
             var lines = text.ToNotEmptyLines().TrimStringArray();
             lines[0].Should().StartWithEquivalent("CommandLine");
             lines[1].Should().StartWithEquivalent("Copyright (c)");


### PR DESCRIPTION
The attribute Hidden has been added to OptionAttribute, ValueAttribute,
and VerbAttribute.  By default it is false.

Changes to support this new attribute so that if hidden it is not
visible in the help text, but is still usable if called correctly. If
you ask for help on a hidden verb you will get the help displayed but
hidden options will still be hidden. Allowing for hidden verbs with not
hidden options.

Resolves issue #263 

I would really recommend some additional real world testing over and above what I have done. If @gfody @otherdave and/or @nemec could help with that I would really appreciate the extra testing effort on this new feature.