### PR TITLE
Fixing project refs so tests build on dotnet core

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "projects": [
-    "tests/CommandLine.Tests",
-    "src/CommandLine"
+    "src",
+    "tests"
   ],
   "sdk": {
     "version": "1.0.0-preview2-003121"

--- a/tests/CommandLine.Tests/project.json
+++ b/tests/CommandLine.Tests/project.json
@@ -4,7 +4,9 @@
 
   "dependencies": {
     "xunit": "2.1.0",
-    "CommandLine": "2.0.275"
+    "CommandLine": {
+      "target": "project"
+    }
   },
 
   "testRunner": "xunit",


### PR DESCRIPTION
Tests wouldn't build on dotnet core because the root global.json was set up incorrectly to use the "target": "project" dependency style.

I've fixed this and I verified that the tests can run and pass on dotnet core.

This resolves issue #330 