### PR TITLE
Fix infinite loop in HelpText.Addline; add unit test + validation

### DIFF
--- a/src/CommandLine/Text/HelpText.cs
+++ b/src/CommandLine/Text/HelpText.cs
@@ -206,7 +206,7 @@ namespace CommandLine.Text
         public static HelpText AutoBuild<T>(
             ParserResult<T> parserResult,
             Func<HelpText, HelpText> onError,
-            Func<Example, Example> onExample, 
+            Func<Example, Example> onExample,
             bool verbsIndex = false,
             int maxDisplayWidth = DefaultMaximumLength)
         {
@@ -254,7 +254,7 @@ namespace CommandLine.Text
 
             usageAttr.Do(
                 usage => usage.AddToHelpText(auto, true));
-            
+
             usageLines.Do(
                 lines => auto.AddPreOptionsLines(lines));
 
@@ -519,7 +519,7 @@ namespace CommandLine.Text
                 yield return line.ToString();
             }
 
-            var mutuallyErrs = 
+            var mutuallyErrs =
                 formatMutuallyExclusiveSetErrors(
                     meaningfulErrors.OfType<MutuallyExclusiveSetError>());
             if (mutuallyErrs.Length > 0)
@@ -619,8 +619,25 @@ namespace CommandLine.Text
                 .ToString();
         }
 
-        private static void AddLine(StringBuilder builder, string value, int maximumLength)
+        internal static void AddLine(StringBuilder builder, string value, int maximumLength)
         {
+            if (builder == null)
+            {
+                throw new ArgumentNullException(nameof(builder));
+            }
+
+            if (value == null)
+            {
+                throw new ArgumentNullException(nameof(value));
+            }
+
+            if (maximumLength < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(value));
+            }
+
+            value = value.Trim();
+
             builder.AppendWhen(builder.Length > 0, Environment.NewLine);
             do
             {

--- a/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
+++ b/tests/CommandLine.Tests/Unit/Text/HelpTextTests.cs
@@ -12,6 +12,7 @@ using CommandLine.Tests.Unit.Infrastructure;
 using CommandLine.Text;
 using FluentAssertions;
 using Xunit;
+using System.Text;
 
 namespace CommandLine.Tests.Unit.Text
 {
@@ -656,6 +657,17 @@ namespace CommandLine.Tests.Unit.Text
             {
                 ReflectionHelper.SetAttributeOverride(null);
             }
+        }
+
+        [Fact]
+        public void Add_line_with_two_empty_spaces_at_the_end()
+        {
+            StringBuilder b = new StringBuilder();
+            HelpText.AddLine(b,
+                "Test  ",
+                1);
+
+            Assert.Equal("T" + Environment.NewLine + "e" + Environment.NewLine + "s" + Environment.NewLine + "t", b.ToString());
         }
     }
 }


### PR DESCRIPTION
This PR fixes an issue where `HelpText.AddLine` would end up in an infinite loop if `value` ended with multiple spaces, and adds a unit test for that.

It also adds some additional parameter validation for values which otherwise would cause the method to fail.

Fixes #387