### PR TITLE
ReadText.Demo: update nuget to latest beta

### DIFF
--- a/demo/ReadText.Demo/ReadText.Demo.csproj
+++ b/demo/ReadText.Demo/ReadText.Demo.csproj
@@ -29,9 +29,8 @@
     <Externalconsole>true</Externalconsole>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="CommandLine, Version=2.0.251.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
-      <HintPath>packages\CommandLineParser.2.0.251-beta\lib\net40\CommandLine.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="CommandLine, Version=2.0.275.0, Culture=neutral, PublicKeyToken=de6f01bd326f8c32, processorArchitecture=MSIL">
+      <HintPath>packages\CommandLineParser.2.1.1-beta\lib\net40\CommandLine.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -45,7 +44,9 @@
     <Compile Include="Options.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/demo/ReadText.Demo/packages.config
+++ b/demo/ReadText.Demo/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="CommandLineParser" version="2.0.251-beta" targetFramework="net4" />
+  <package id="CommandLineParser" version="2.1.1-beta" targetFramework="net40" />
 </packages>


### PR DESCRIPTION
bug in described in #377 issue 1 (missing space) has already been fixed since 2.0.257

c# demo was still using 2.0.251, while vb.net demo was already using 2.1.1 