### PR TITLE
Fix for no value if [Option] arg equals to [Value] arg

### DIFF
--- a/src/CommandLine/CommandLine.csproj
+++ b/src/CommandLine/CommandLine.csproj
@@ -84,6 +84,7 @@
     <Compile Include="Infrastructure\ExceptionExtensions.cs" />
     <Compile Include="Infrastructure\FSharpOptionHelper.cs" />
     <Compile Include="Infrastructure\PopsicleSetter.cs" />
+    <Compile Include="Infrastructure\ReferenceEqualityComparer.cs" />
     <Compile Include="Infrastructure\ReflectionHelper.cs" />
     <Compile Include="Infrastructure\ResultExtensions.cs" />
     <Compile Include="Infrastructure\StringExtensions.cs" />

--- a/src/CommandLine/Core/TokenPartitioner.cs
+++ b/src/CommandLine/Core/TokenPartitioner.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using CommandLine.Infrastructure;
 using CSharpx;
 
 namespace CommandLine.Core
@@ -23,11 +24,11 @@ namespace CommandLine.Core
             var scalars = Scalar.Partition(tokenList, typeLookup).Memorize();
             var sequences = Sequence.Partition(tokenList, typeLookup).Memorize();
             var nonOptions = tokenList
-                .Where(t => !switches.Contains(t))
-                .Where(t => !scalars.Contains(t))
-                .Where(t => !sequences.Contains(t)).Memorize();
+                .Where(t => !switches.Contains(t, ReferenceEqualityComparer.Default))
+                .Where(t => !scalars.Contains(t, ReferenceEqualityComparer.Default))
+                .Where(t => !sequences.Contains(t, ReferenceEqualityComparer.Default)).Memorize();
             var values = nonOptions.Where(v => v.IsValue()).Memorize();
-            var errors = nonOptions.Except(values).Memorize();
+            var errors = nonOptions.Except(values, ReferenceEqualityComparer.Default).Cast<Token>().Memorize();
 
             return Tuple.Create(
                     KeyValuePairHelper.ForSwitch(switches)

--- a/src/CommandLine/Infrastructure/ReferenceEqualityComparer.cs
+++ b/src/CommandLine/Infrastructure/ReferenceEqualityComparer.cs
@@ -1,0 +1,24 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace CommandLine.Infrastructure
+{
+    internal sealed class ReferenceEqualityComparer : IEqualityComparer, IEqualityComparer<object>
+    {
+        public static readonly ReferenceEqualityComparer Default = new ReferenceEqualityComparer();
+
+        public new bool Equals(object x, object y)
+        {
+            return x == y; // reference equality because operator== is static and resolved at compile-time
+        }
+
+        public int GetHashCode(object obj)
+        {
+            return RuntimeHelpers.GetHashCode(obj);
+        }
+    }
+}

--- a/tests/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/tests/CommandLine.Tests/CommandLine.Tests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="CultureInfoExtensions.cs" />
     <Compile Include="Fakes\Options_With_Default_Set_To_Sequence.cs" />
     <Compile Include="Fakes\Options_With_Guid.cs" />
+    <Compile Include="Fakes\Options_With_Option_And_Value_Of_String_Type.cs" />
     <Compile Include="Fakes\Options_With_SetName_That_Ends_With_Previous_SetName.cs" />
     <Compile Include="Fakes\Options_With_Uri_And_SimpleType.cs" />
     <Compile Include="Fakes\Options_With_Switches.cs" />

--- a/tests/CommandLine.Tests/Fakes/Options_With_Option_And_Value_Of_String_Type.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Option_And_Value_Of_String_Type.cs
@@ -1,0 +1,16 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Option_And_Value_Of_String_Type
+    {
+        [Option('o', "opt")]
+        public string OptValue { get; set; }
+
+        [Value(0)]
+        public string PosValue { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Fakes/Verb_Fakes.cs
+++ b/tests/CommandLine.Tests/Fakes/Verb_Fakes.cs
@@ -75,4 +75,14 @@ namespace CommandLine.Tests.Fakes
             HelpText = "Allow adding otherwise ignored files.")]
         public bool Force { get; set; }
     }
+
+    [Verb("test")]
+    class Verb_With_Option_And_Value_Of_String_Type
+    {
+        [Option('o', "opt")]
+        public string OptValue { get; set; }
+
+        [Value(0)]
+        public string PosValue { get; set; }
+    }
 }

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -803,5 +803,35 @@ namespace CommandLine.Tests.Unit
             [Option('u', "user", Default = null)]
             public string User { get; set; }
         }
+
+        [Fact]
+        public void Parse_options_with_same_option_and_value_args()
+        {
+            var parser = Parser.Default;
+            parser.ParseArguments<Options_With_Option_And_Value_Of_String_Type>(
+                new[] { "arg", "-o", "arg" })
+                .WithNotParsed(errors => { throw new InvalidOperationException("Must be parsed."); })
+                .WithParsed(args =>
+                {
+                    Assert.Equal("arg", args.OptValue);
+                    Assert.Equal("arg", args.PosValue);
+                });
+        }
+
+        [Fact]
+        public void Parse_verb_with_same_option_and_value_args()
+        {
+            var parser = Parser.Default;
+            var result = parser.ParseArguments(
+                new[] { "test", "arg", "-o", "arg" }, 
+                typeof(Verb_With_Option_And_Value_Of_String_Type));
+            result
+                .WithNotParsed(errors => { throw new InvalidOperationException("Must be parsed."); })
+                .WithParsed<Verb_With_Option_And_Value_Of_String_Type>(args =>
+                {
+                    Assert.Equal("arg", args.OptValue);
+                    Assert.Equal("arg", args.PosValue);
+                });
+        }
     }
 }


### PR DESCRIPTION
Make comparisons by reference in TokenPartitioner. Fixes #398.