### PR TITLE
User [Value] index when parsing

### DIFF
--- a/src/CommandLine/Core/InstanceBuilder.cs
+++ b/src/CommandLine/Core/InstanceBuilder.cs
@@ -67,7 +67,7 @@ namespace CommandLine.Core
 
                 var valueSpecPropsResult =
                     ValueMapper.MapValues(
-                        (from pt in specProps where pt.Specification.IsValue() select pt),
+                        (from pt in specProps where pt.Specification.IsValue() orderby ((ValueSpecification)pt.Specification).Index select pt),
                         valuesPartition,
                         (vals, type, isScalar) => TypeConverter.ChangeType(vals, type, isScalar, parsingCulture, ignoreValueCase));
 

--- a/tests/CommandLine.Tests/CommandLine.Tests.csproj
+++ b/tests/CommandLine.Tests/CommandLine.Tests.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Fakes\Options_With_Default_Set_To_Sequence.cs" />
     <Compile Include="Fakes\Options_With_Guid.cs" />
     <Compile Include="Fakes\Options_With_SetName_That_Ends_With_Previous_SetName.cs" />
+    <Compile Include="Fakes\Options_With_Shuffled_Index_Values.cs" />
     <Compile Include="Fakes\Options_With_Uri_And_SimpleType.cs" />
     <Compile Include="Fakes\Options_With_Switches.cs" />
     <Compile Include="Fakes\Options_With_Two_Option_Required_Set_To_True_And_Two_Sets.cs" />

--- a/tests/CommandLine.Tests/Fakes/Options_With_Shuffled_Index_Values.cs
+++ b/tests/CommandLine.Tests/Fakes/Options_With_Shuffled_Index_Values.cs
@@ -1,0 +1,19 @@
+﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
+
+using System;
+using System.Linq;
+
+namespace CommandLine.Tests.Fakes
+{
+    class Options_With_Shuffled_Index_Values
+    {
+        [Value(1)]
+        public string Arg1 { get; set; }
+
+        [Value(2)]
+        public string Arg2 { get; set; }
+
+        [Value(0)]
+        public string Arg0 { get; set; }
+    }
+}

--- a/tests/CommandLine.Tests/Unit/ParserTests.cs
+++ b/tests/CommandLine.Tests/Unit/ParserTests.cs
@@ -803,5 +803,20 @@ namespace CommandLine.Tests.Unit
             [Option('u', "user", Default = null)]
             public string User { get; set; }
         }
+
+        [Fact]
+        public void Parse_options_with_shuffled_index_values()
+        {
+            var parser = Parser.Default;
+            parser.ParseArguments<Options_With_Shuffled_Index_Values>(
+                new[] { "zero", "one", "two" })
+                .WithNotParsed(errors => { throw new InvalidOperationException("Must be parsed."); })
+                .WithParsed(args =>
+                {
+                    Assert.Equal("zero", args.Arg0);
+                    Assert.Equal("one", args.Arg1);
+                    Assert.Equal("two", args.Arg2);
+                });
+        }
     }
 }


### PR DESCRIPTION
Fixes value parsing depending on properties order. Fixes #336 and #397.

"User" -> "Use" typo.