### PR TITLE
Pass CaseInsensitiveEnumValues property value to InstanceChooser.Choose

### DIFF
--- a/src/CommandLine/Core/InstanceChooser.cs
+++ b/src/CommandLine/Core/InstanceChooser.cs
@@ -17,6 +17,7 @@ namespace CommandLine.Core
             IEnumerable<Type> types,
             IEnumerable<string> arguments,
             StringComparer nameComparer,
+            bool ignoreValueCase,
             CultureInfo parsingCulture,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -36,7 +37,7 @@ namespace CommandLine.Core
                             arguments.Skip(1).FirstOrDefault() ?? string.Empty, nameComparer))
                     : preprocCompare("version")
                         ? MakeNotParsed(types, new VersionRequestedError())
-                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, parsingCulture, nonFatalErrors);
+                        : MatchVerb(tokenizer, verbs, arguments, nameComparer, ignoreValueCase, parsingCulture, nonFatalErrors);
             };
 
             return arguments.Any()
@@ -49,6 +50,7 @@ namespace CommandLine.Core
             IEnumerable<Tuple<Verb, Type>> verbs,
             IEnumerable<string> arguments,
             StringComparer nameComparer,
+            bool ignoreValueCase,
             CultureInfo parsingCulture,
             IEnumerable<ErrorType> nonFatalErrors)
         {
@@ -60,7 +62,7 @@ namespace CommandLine.Core
                     tokenizer,
                     arguments.Skip(1),
                     nameComparer,
-                    false,
+                    ignoreValueCase,
                     parsingCulture,
                     nonFatalErrors)
                 : MakeNotParsed(verbs.Select(v => v.Item2), new BadVerbSelectedError(arguments.First()));

--- a/src/CommandLine/Parser.cs
+++ b/src/CommandLine/Parser.cs
@@ -156,6 +156,7 @@ namespace CommandLine
                     types,
                     args,
                     settings.NameComparer,
+                    settings.CaseInsensitiveEnumValues,
                     settings.ParsingCulture,
                     HandleUnknownArguments(settings.IgnoreUnknownArguments)),
                 settings);

--- a/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
+++ b/tests/CommandLine.Tests/Unit/Core/InstanceChooserTests.cs
@@ -22,6 +22,7 @@ namespace CommandLine.Tests.Unit.Core
                 types,
                 arguments,
                 StringComparer.Ordinal,
+                false,
                 CultureInfo.InvariantCulture,
                 Enumerable.Empty<ErrorType>());
         }


### PR DESCRIPTION
It is a bugfix for #289 and #326 . When using the `ParserResult<object> ParseArguments(IEnumerable<string>, Type[])` method, `CaseInsensitiveEnumValues` property was not working, because it was not passed to `InstanceChooser.Choose` method.
