### PR TITLE
Bugfix: Parameter name matches previous parameter value

### DIFF
--- a/src/CommandLine/Core/KeyValuePairHelper.cs
+++ b/src/CommandLine/Core/KeyValuePairHelper.cs
@@ -1,8 +1,9 @@
 ﻿// Copyright 2005-2015 Giacomo Stelluti Scala & Contributors. All rights reserved. See License.md in the project root for license information.
 
+using CommandLine.Infrastructure;
+using CSharpx;
 using System.Collections.Generic;
 using System.Linq;
-using CSharpx;
 
 namespace CommandLine.Core
 {
@@ -17,7 +18,9 @@ namespace CommandLine.Core
         public static IEnumerable<KeyValuePair<string, IEnumerable<string>>> ForScalar(
             IEnumerable<Token> tokens)
         {
-            return tokens.Pairwise((f, s) => f.Text.ToKeyValuePair(s.Text));
+            return tokens
+                .Group(2)
+                .Select((g) => g[0].Text.ToKeyValuePair(g[1].Text));
         }
 
         public static IEnumerable<KeyValuePair<string, IEnumerable<string>>> ForSequence(

--- a/src/CommandLine/Infrastructure/EnumerableExtensions`1.cs
+++ b/src/CommandLine/Infrastructure/EnumerableExtensions`1.cs
@@ -33,5 +33,36 @@ namespace CommandLine.Infrastructure
         {
             return !source.Any();
         }
+
+        /// <summary>
+        /// Breaks a collection into groups of a specified size.
+        /// </summary>
+        /// <param name="source">A collection of <typeparam name="T"/>.
+        /// <param name="groupSize">The number of items each group shall contain.</param>
+        /// <returns>An enumeration of <typeparam name="T"/>[].</returns>
+        /// <remarks>An incomplete group at the end of the source collection will be silently dropped.</remarks>
+        public static IEnumerable<T[]> Group<T>(this IEnumerable<T> source, int groupSize)
+        {
+            if (groupSize < 1)
+            {
+                throw new ArgumentOutOfRangeException(nameof(groupSize));
+            }
+
+            T[] group = new T[groupSize];
+            int groupIndex = 0;
+
+            foreach (var item in source)
+            {
+                group[groupIndex++] = item;
+
+                if (groupIndex == groupSize)
+                {
+                    yield return group;
+
+                    group = new T[groupSize];
+                    groupIndex = 0;
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
When processing scalar tokens, use the correct grouping routine.

This fixes a strange bug where a parameter name matching the previous parameter values causes the second parameter value to match it's name. Consider these two command lines:

var works = new string[] { "--argument1", "argument1Value", "--argument2", "argument2Value" };`
var doesNotWork = new string[] { "--argument1", "argument2", "--argument2", "argument2Value" };

After parsing doesNotWork, the value of --argument2 will be "argument2", instead of the expected "argument2Value".